### PR TITLE
Removed reference to RevoScalePy

### DIFF
--- a/docs/convert-model-winmltools.md
+++ b/docs/convert-model-winmltools.md
@@ -18,7 +18,6 @@ ms.localizationpriority: medium
 - scikit-learn (subset of models convertible to ONNX)
 - xgboost
 - libSVM
-- RevoScalePy
 - Keras
 
 To learn how to export from other ML frameworks, take a look at [ONNX tutorials](https://github.com/onnx/tutorials) on GitHub.


### PR DESCRIPTION
RevoScalePy is not included in winmltools and have been added in the docs by mistake