### PR TITLE
Tensorization happens during bind not evaluation.

### DIFF
--- a/docs/integrate-model.md
+++ b/docs/integrate-model.md
@@ -136,7 +136,7 @@ Most models use the following formats, but this is not universal to all models.
 
 #### Tensorization
 
-Images are represented in Windows ML in a tensor format. Tensorization is the process of converting an image into a tensor and happens during evaluation.
+Images are represented in Windows ML in a tensor format. Tensorization is the process of converting an image into a tensor and happens during bind.
 
 Windows ML converts images into 4 dimensional tensors of 32bit floats in the "NCHW tensor format":
 * N is batch size (or number of images). Windows ML currently supports a batch size N of 1.


### PR DESCRIPTION
An issue was filed on WinML GitHub where the customer pointed out that our docs say that tensorization happens on evaluation. https://github.com/Microsoft/Windows-Machine-Learning/issues/132#issuecomment-457689179

This change fixes this statement.