### PR TITLE
Update custom operators URL

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -53,7 +53,7 @@ landingContent:
           - text: Core APIs (Windows.AI.MachineLearning Namespace)
             url: https://docs.microsoft.com/uwp/api/windows.ai.machinelearning
           - text: Custom operators
-            url: https://docs.microsoft.com/en-us/windows/ai/windows-ml/custom-operator
+            url: https://docs.microsoft.com/en-us/windows/ai/windows-ml/custom-operators
           - text: WinML native APIs
             url: https://docs.microsoft.com/en-us/windows/ai/windows-ml/native-apis
           - text: Tools and Samples


### PR DESCRIPTION
Appending an "s" to fix a broken URL path for the "Custom operators" heading link