### PR TITLE
Update WSL kernel version

### DIFF
--- a/docs/directml/gpu-cuda-in-wsl.md
+++ b/docs/directml/gpu-cuda-in-wsl.md
@@ -31,7 +31,7 @@ Once you've installed the above driver, ensure you [enable WSL 2](/windows/wsl/i
 > [!NOTE]
 > Ensure you have **Receive updates for other Microsoft products when you update Windows** enabled. You can find it in **Advanced options** within the **Windows Update** section of the Settings app. 
 
-For these features, you need a kernel version of 4.19.121 or higher. You can check the version number by running the following command in PowerShell. 
+For these features, you need a kernel version of 5.10.43.3 or higher. You can check the version number by running the following command in PowerShell. 
 
 ```powershell
 wsl cat /proc/version

--- a/docs/directml/gpu-tensorflow-wsl.md
+++ b/docs/directml/gpu-tensorflow-wsl.md
@@ -54,7 +54,7 @@ Once you've installed the above driver, ensure you [enable WSL](/windows/wsl/ins
 > [!NOTE]
 > Ensure you have the **Receive updates for other Microsoft products when you update Windows** enabled. You can find it in **Advanced options** within the **Windows Update** section of the Settings app. 
 
-For these features, you need a kernel version of 4.19.121 or higher. You can check the version number by running the following command in PowerShell. 
+For these features, you need a kernel version of 5.10.43.3 or higher. You can check the version number by running the following command in PowerShell. 
 
 ```
 wsl cat /proc/version


### PR DESCRIPTION
Updating the minimum WSL kernel version needed to work with Windows 10, version 21H2.