### PR TITLE
Add DALL-E tutorials to AI TOC

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -476,4 +476,6 @@
 ### [API list](windows-ml-container/api-list.md)
 ## Code samples and How-tos
 ### [Add OpenAI chat completions to your WinUI 3 / Windows App SDK desktop app](/windows/apps/how-tos/chatgpt-openai-winui3)
-### [Tutorial: Create a recommendation app with .NET MAUI and ChatGPT](/windows/apps/windows-dotnet-maui/tutorial-maui-ai)
+### [Add DALL-E to your WinUI 3 / Windows App SDK desktop app](/windows/apps/how-tos/dall-e-winui3)
+### [Create a recommendation app with .NET MAUI and ChatGPT](/windows/apps/windows-dotnet-maui/tutorial-maui-ai)
+### [Add DALL-E to your .NET MAUI Windows desktop app](/windows/apps/windows-dotnet-maui/dall-e-maui-windows)


### PR DESCRIPTION
Adding the WinUI  and .NET MAUI Windows tutorials for using DALL-E with the OpenAI APIs to the Windows AI TOC.