### PR TITLE
DirectML hard swish, fix default values (ns-directml-dml_activation_hard_swish_operator_desc.md)

### DIFF
--- a/docs/directml/api/ns-directml-dml_activation_hard_swish_operator_desc.md
+++ b/docs/directml/api/ns-directml-dml_activation_hard_swish_operator_desc.md
@@ -84,13 +84,13 @@ The output tensor to write the results to.
 
 Type: [**FLOAT**](/windows/win32/winprog/windows-data-types)
 
-The alpha coefficient. A typical default for this value is 0.2.
+The scale coefficient. A typical default for this value is 0.166667 (1/6).
 
 `Beta`
 
 Type: [**FLOAT**](/windows/win32/winprog/windows-data-types)
 
-The beta coefficient.
+The bias coefficient. A typical default for this value is 0.5.
 
 ## Availability
 This operator was introduced in **DML_FEATURE_LEVEL_6_2**.


### PR DESCRIPTION
Fix default values. The correct default values for the scale (alpha) and bias (beta) should be 1/6 and 0.5, not 1/5.

(appears this was a typo copy pasta from hard sigmoid)