### PR TITLE
Make single empty line after using statement

### DIFF
--- a/docs/apis/phi-silica.md
+++ b/docs/apis/phi-silica.md
@@ -54,7 +54,6 @@ This example shows how to generate a response to a Q&A prompt where the full res
 ```csharp
 using Microsoft.Windows.AI.Generative; 
  
- 
 if (!LanguageModel.IsAvailable()) 
 { 
    var op = await LanguageModel.MakeAvailableAsync(); 


### PR DESCRIPTION
This keeps the code block consistent across the Windows AI docs, as we have at all other places a single empty line between the using statement(s) and the actuall code.