### PR TITLE
Incorporate latest API changes in code examples

### DIFF
--- a/docs/apis/get-started.md
+++ b/docs/apis/get-started.md
@@ -197,9 +197,9 @@ The following snippet shows how to check for model availability and generate a r
             if (LanguageModel.GetReadyState() == AIFeatureReadyState.EnsureNeeded)
             {
                 var result = await LanguageModel.EnsureReadyAsync();
-                if (result.Status != PackageDeploymentStatus.CompletedSuccess)
+                if (result.Status != AIFeatureReadyResultState.Success)
                 {
-                    throw new Exception(result.ExtendedError().Message);
+                    throw new Exception(result.ExtendedError.Message);
                 }
             }            
 
@@ -207,8 +207,8 @@ The following snippet shows how to check for model availability and generate a r
                await LanguageModel.CreateAsync();
 
             string prompt = "Provide the molecular formula of glucose.";
-            var result = await languageModel.GenerateResponseAsync(prompt);
-            OutputText.Text = result.Response;
+            var response = await languageModel.GenerateResponseAsync(prompt);
+            OutputText.Text = response.Text;
         }
     }
     ```
@@ -249,17 +249,17 @@ The following snippet shows how to check for model availability and generate a r
             if (LanguageModel.GetReadyState() == AIFeatureReadyState.EnsureNeeded)
             {
                 var result = await LanguageModel.EnsureReadyAsync();
-                if (result.Status != PackageDeploymentStatus.CompletedSuccess)
+                if (result.Status != AIFeatureReadyResultState.Success)
                 {
-                    throw new Exception(result.ExtendedError().Message);
+                    throw new Exception(result.ExtendedError.Message);
                 }
             }            
 
             using LanguageModel languageModel = await LanguageModel.CreateAsync();
 
             string prompt = "Provide the molecular formula for glucose.";
-            var result = await languageModel.GenerateResponseAsync(prompt);
-            OutputText.Text = result.Response;
+            var response = await languageModel.GenerateResponseAsync(prompt);
+            OutputText.Text = response.Text;
         }
     }
     ```
@@ -296,17 +296,17 @@ The following snippet shows how to check for model availability and generate a r
             if (LanguageModel.GetReadyState() == AIFeatureReadyState.EnsureNeeded)
             {
                 var result = await LanguageModel.EnsureReadyAsync();
-                if (result.Status != PackageDeploymentStatus.CompletedSuccess)
+                if (result.Status != AIFeatureReadyResultState.Success)
                 {
-                    throw new Exception(result.ExtendedError().Message);
+                    throw new Exception(result.ExtendedError.Message);
                 }
             }            
 
             using LanguageModel languageModel = await LanguageModel.CreateAsync();
 
             string prompt = "Provide the molecular formula for glucose.";
-            var result = await languageModel.GenerateResponseAsync(prompt);
-            OutputLabel.Text = result.Response;
+            var response = await languageModel.GenerateResponseAsync(prompt);
+            OutputLabel.Text = response.Text;
         }
     }
     ```

--- a/docs/apis/imaging-tutorial.md
+++ b/docs/apis/imaging-tutorial.md
@@ -56,9 +56,9 @@ In the second file listed above, you'll find the following function, which demon
                     if (ImageScaler.GetReadyState() == AIFeatureReadyState.EnsureNeeded)
                     {
                         var op = await ImageScaler.EnsureReadyAsync();
-                        if (op.Status != PackageDeploymentStatus.CompletedSuccess)
+                        if (op.Status != AIFeatureReadyResultState.Success)
                         {
-                            throw new Exception(op.ExtendedError().Message);
+                            throw new Exception(op.ExtendedError.Message);
                         }
                     }
 

--- a/docs/apis/imaging.md
+++ b/docs/apis/imaging.md
@@ -46,7 +46,7 @@ using Windows.Graphics.Imaging;
 if (ImageScaler.GetReadyState() == AIFeatureReadyState.EnsureNeeded) 
 {
     var result = await ImageScaler.EnsureReadyAsync();
-    if (result.Status != PackageDeploymentStatus.CompletedSuccess)
+    if (result.Status != AIFeatureReadyResultState.Success)
     {
         throw result.ExtendedError;
     }
@@ -69,7 +69,7 @@ using namespace winrt::Windows::Graphics::Imaging;
 if (ImageScaler::GetReadyState() == AIFeatureReadyState::EnsureNeeded) 
 { 
     winrt::PackageDeploymentResult result = ImageScaler::EnsureReadyAsync().get(); 
-    if (result.Status() != PackageDeploymentStatus::CompletedSuccess)
+    if (result.Status() != AIFeatureReadyResultState::Success)
     {
        throw result.ExtendedError();
     }
@@ -128,7 +128,7 @@ using Windows.Graphics.Imaging;
 if (ImageDescriptionGenerator.GetReadyState() == AIFeatureReadyState.EnsureNeeded) 
 {
     var result = await ImageDescriptionGenerator.EnsureReadyAsync();
-    if (result.Status != PackageDeploymentStatus.CompletedSuccess)
+    if (result.Status != AIFeatureReadyResultState.Success)
     {
         throw result.ExtendedError;
     }
@@ -145,8 +145,8 @@ filterOptions.PromptMinSeverityLevelToBlock.ViolentContentSeverity = SeverityLev
 filterOptions.ResponseMinSeverityLevelToBlock.ViolentContentSeverity = SeverityLevel.Medium;
 
 // Get text description.
-LanguageModelResponse languageModelResponse = await imageDescriptionGenerator.DescribeAsync(inputImage, ImageDescriptionScenario.Caption, filterOptions);
-string response = languageModelResponse.Response;
+LanguageModelResponseResult languageModelResponseResult = await imageDescriptionGenerator.DescribeAsync(inputImage, ImageDescriptionScenario.Caption, filterOptions);
+string response = languageModelResponseResult.Text;
 
 ```
 
@@ -171,7 +171,7 @@ using namespace winrt::Windows::Storage::StorageFile;
 if (ImageDescriptionGenerator::GetReadyState() == AIFeatureReadyState::EnsureNeeded) 
 { 
     winrt::PackageDeploymentResult result = ImageDescriptionGenerator::EnsureReadyAsync().get(); 
-    if (result.Status() != PackageDeploymentStatus::CompletedSuccess)
+    if (result.Status() != AIFeatureReadyResultState::Success)
     {
        throw result.ExtendedError();
     }
@@ -188,8 +188,8 @@ auto inputBuffer = ImageBuffer::CreateCopyFromBitmap(softwareBitmap);
 
 
 // Get text description.
-LanguageModelResponse languageModelResponse = imageDescriptionGenerator.DescribeAsync(inputImage, ImageDescriptionScenario::Caption, contentFilter).get();
-string text = languageModelResponse.Response();
+LanguageModelResponseResult languageModelResponseResult = imageDescriptionGenerator.DescribeAsync(inputImage, ImageDescriptionScenario::Caption, contentFilter).get();
+string text = languageModelResponseResult.Text();
 ```
 
 ## What can I do with Image Segmentation?
@@ -233,7 +233,7 @@ using Windows.Graphics.Imaging;
 if (ImageObjectExtractor::GetReadyState() == AIFeatureReadyState.EnsureNeeded) 
 {
     var result = await ImageObjectExtractor.EnsureReadyAsync();
-    if (result.Status != PackageDeploymentStatus.CompletedSuccess)
+    if (result.Status != AIFeatureReadyResultState.Success)
     {
         throw result.ExtendedError;
     }
@@ -263,7 +263,7 @@ using namespace winrt::Windows::Foundation;
 if (ImageObjectExtractor::GetReadyState() == AIFeatureReadyState::EnsureNeeded) 
 { 
     winrt::PackageDeploymentResult result = ImageObjectExtractor::EnsureReadyAsync().get(); 
-    if (result.Status() != PackageDeploymentStatus::CompletedSuccess)
+    if (result.Status() != AIFeatureReadyResultState::Success)
     {
        throw result.ExtendedError();
     }
@@ -355,7 +355,7 @@ using Windows.Graphics.Imaging;
 if (ImageObjectRemover::GetReadyState() == AIFeatureReadyState.EnsureNeeded) 
 {
     var result = await ImageObjectRemover.EnsureReadyAsync();
-    if (result.Status != PackageDeploymentStatus.CompletedSuccess)
+    if (result.Status != AIFeatureReadyResultState.Success)
     {
         throw result.ExtendedError;
     }
@@ -377,7 +377,7 @@ using namespace winrt::Windows::Foundation;
 if (ImageObjectRemover::GetReadyState() == AIFeatureReadyState::EnsureNeeded) 
 { 
     winrt::PackageDeploymentResult result = ImageObjectRemover::EnsureReadyAsync().get(); 
-    if (result.Status() != PackageDeploymentStatus::CompletedSuccess)
+    if (result.Status() != AIFeatureReadyResultState::Success)
     {
        throw result.ExtendedError();
     } 

--- a/docs/apis/phi-silica-tutorial.md
+++ b/docs/apis/phi-silica-tutorial.md
@@ -32,9 +32,9 @@ In the second file listed above, you'll find the following function, which demon
             {
                 answer.Text = "Making LanguageModel available...";
                 var op = await LanguageModel.EnsureReadyAsync();
-                if (op.Status != PackageDeploymentStatus.CompletedSuccess)
+                if (op.Status != AIFeatureReadyResultState.Success)
                 {
-                    throw new Exception(op.ExtendedError().Message);
+                    throw new Exception(op.ExtendedError.Message);
                 }
             }
 
@@ -44,7 +44,7 @@ In the second file listed above, you'll find the following function, which demon
             string prompt = entryPrompt.Text;
 
             answer.Text = "Generating response...";
-            Windows.Foundation.AsyncOperationProgressHandler<LanguageModelResponse, string>
+            Windows.Foundation.AsyncOperationProgressHandler<LanguageModelResponseResult, string>
             progressHandler = (asyncInfo, delta) =>
             {
                 System.Diagnostics.Debug.WriteLine($"Progress: {delta}");
@@ -58,8 +58,8 @@ In the second file listed above, you'll find the following function, which demon
 
             asyncOp.Progress = progressHandler;
 
-            var result = await asyncOp;
-            System.Diagnostics.Debug.WriteLine("DONE: " + result.Response);
+            var response = await asyncOp;
+            System.Diagnostics.Debug.WriteLine("DONE: " + response.Text);
         }
 ```
 ![The sample app after calling the ImageScaler and LanguageModel APIs.](../images/API-Tutorial-MAUIappimage2(aftercallingSuperResandLanguageModelAPIs).png)

--- a/docs/apis/phi-silica.md
+++ b/docs/apis/phi-silica.md
@@ -135,7 +135,7 @@ This example shows how to generate a response to a Q&A prompt where the response
 
 1. Create a **LanguageModel** object to reference the local language model. *A check has already been performed to ensure the Phi Silica language model is available on the user's device in the previous snippet.
 
-1. Asynchronously retrieve the **LanguageModelResponse** in a call to **GenerateResponseWithProgressAsync**. Write it to the console as the response is generated.
+1. Asynchronously retrieve the **LanguageModelResponseResult** in a call to **GenerateResponseAsync**. Write it to the console as the response is generated.
 
 ### [C#](#tab/csharp2)
 ```csharp
@@ -143,14 +143,14 @@ using LanguageModel languageModel = await LanguageModel.CreateAsync();
  
 string prompt = "Introduce yourself."; 
  
-AsyncOperationProgressHandler<LanguageModelResponse, string> 
+AsyncOperationProgressHandler<LanguageModelResponseResult, string> 
 progressHandler = (asyncInfo, delta) => 
 { 
     Console.WriteLine($"Progress: {delta}"); 
-    Console.WriteLine($"Response so far: {asyncInfo.GetResults().Response}"); 
+    Console.WriteLine($"Response so far: {asyncInfo.GetResults().Text}"); 
  }; 
  
-var asyncOp = languageModel.GenerateResponseWithProgressAsync(prompt); 
+var asyncOp = languageModel.GenerateResponseAsync(prompt); 
  
 asyncOp.Progress = progressHandler; 
  
@@ -165,14 +165,14 @@ auto languageModel = LanguageModel::CreateAsync().get();
 
 std::string prompt = "Introduce yourself.";
 
-AsyncOperationProgressHandler<LanguageModelResponse, std::string> progressHandler = 
-    [](const IAsyncOperationWithProgress<LanguageModelResponse, std::string>& asyncInfo, const std::string& delta) 
+AsyncOperationProgressHandler<LanguageModelResponseResult, std::string> progressHandler = 
+    [](const IAsyncOperationWithProgress<LanguageModelResponseResult, std::string>& asyncInfo, const std::string& delta) 
     { 
         std::cout << "Progress: " << delta << std::endl; 
-        std::cout << "Response so far: " << asyncInfo.GetResults().Response << std::endl; 
+        std::cout << "Response so far: " << asyncInfo.GetResults().Text << std::endl; 
     };
 
-auto asyncOp = languageModel.GenerateResponseWithProgressAsync(prompt);
+auto asyncOp = languageModel.GenerateResponseAsync(prompt);
 
 asyncOp.Progress(progressHandler); 
 
@@ -201,7 +201,7 @@ Phi Silica includes the ability to predefine text response formats for use in yo
     | **LanguageModelSkill.Summarize**    | Return a summary based on the prompt text.  |
     | **LanguageModelSkill.Rewrite**  | Rewrite the prompt text response to improve clarity and comprehension.  |
 
-3. Then we asynchronously retrieve the **LanguageModelResponse** in a call to **GenerateResponseWithProgressAsync** and write it to the console as the response is generated.
+3. Then we asynchronously retrieve the **LanguageModelResponseResult** in a call to **GenerateResponseAsync** and write it to the console as the response is generated.
 
 ### [C#](#tab/csharp3)
 ```csharp

--- a/docs/apis/text-recognition.md
+++ b/docs/apis/text-recognition.md
@@ -121,9 +121,9 @@ public async Task<TextRecognizer> EnsureModelIsReady()
     if (TextRecognizer.GetReadyState() == AIFeatureReadyState.EnsureNeeded)
     {
         var loadResult = await TextRecognizer.EnsureReadyAsync();
-        if (loadResult.Status != PackageDeploymentStatus.CompletedSuccess)
+        if (loadResult.Status != AIFeatureReadyResultState.Success)
         {
-            throw new Exception(loadResult.ExtendedError().Message);
+            throw new Exception(loadResult.ExtendedError.Message);
         }
     }
 
@@ -160,7 +160,7 @@ winrt::IAsyncOperation<winrt::TextRecognizer> EnsureModelIsReady()
   if (winrt::TextRecognizer::GetReadyState() == AIFeatureReadyState::EnsureNeeded) 
   {
     auto loadResult = co_await winrt::TextRecognizer::EnsureReadyAsync();
-    if (loadResult.Status() != winrt::PackageDeploymentStatus::CompletedSuccess)
+    if (loadResult.Status() != winrt::AIFeatureReadyResultState::Success)
     {
         throw winrt::hresult_error(loadResult.ExtendedError());
     }


### PR DESCRIPTION
With Windows App SDK 1.8-experimental1 some APIs have changed that are not in the docs yet:
- the `PackageDeploymentStatus` enum does not exist anymore. Instead, the `AIFeatureReadyResultState` enum is used.
- `ExtendedError()` is not a method anymore, but a property instead
- `GenerateResponseAsync` returns a `LanguageModelResponseResult` and no more a `LanguageModelResponse` object
- `LanguageModelResponseResult` does not have the response in a `Response` property, but in a `Text` property
- `GenerateResponseWithProgressAsync` does not exist anymore, it's now just `GenerateResponseAsync`
- Some examples contain a `var result` declaration inside an if-statement and a `var result` declaration outside of the if-statement, which causes the code to not compile due to CS0136 error (_A local or parameter named 'result' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter_). I call the variable for the response `response` instead of result to avoid this.

This PR fixes these things in the code examples to make them valid for Windows App SDK 1.8-experimental1. 