### PR TITLE
IS_PASSWORD => IS_PRIVATE in Recall web browser documentation

### DIFF
--- a/docs/recall/recall-web-browsers.md
+++ b/docs/recall/recall-web-browsers.md
@@ -12,7 +12,7 @@ no-loc: [Recall]
 
 Many web browsers support a concept of "InPrivate" browsing, where the user's history does not get saved.
 
-To make sure that Recall doesn't save your user's browsing history while in modes like this, your app can use the [`SetInputScope`](/windows/win32/api/inputscope/nf-inputscope-setinputscope) function, setting the input scope to `IS_PASSWORD`.
+To make sure that Recall doesn't save your user's browsing history while in modes like this, your app can use the [`SetInputScope`](/windows/win32/api/inputscope/nf-inputscope-setinputscope) function, setting the input scope to `IS_PRIVATE`.
 
 > [!IMPORTANT]
 > Your app must also have a `http` or `https` protocol handler registered before `SetInputScope` will support the behavior described in this article.


### PR DESCRIPTION
The `InputScope` is incorrectly named in the documentation text.