### PR TITLE
Update phi-silica.md using statement to compile

### DIFF
--- a/docs/apis/phi-silica.md
+++ b/docs/apis/phi-silica.md
@@ -43,7 +43,7 @@ With a local Phi Silica language model you can generate text responses to user p
 To use Phi Silica, make sure you are using the required namespaces:
 
 ```csharp
-Using Microsoft.Windows.AI;
+using Microsoft.Windows.AI;
 using Microsoft.Windows.AI.Text;
 ```
 


### PR DESCRIPTION
"using" with lowercase u is the only keyword, with uppercase U the compiler is expecting a type thus creating compiler errors.