### PR TITLE
Fixed the User Activity publishing code for Recall

### DIFF
--- a/docs/recall/recall-relaunch.md
+++ b/docs/recall/recall-relaunch.md
@@ -35,7 +35,7 @@ private async Task OnContentChangedAsync()
     var activity = await UserActivityChannel.GetDefault().GetOrCreateUserActivityAsync(id);
 
     // Populate the required properties
-    activity.DisplayText = "doc135.txt";
+    activity.VisualElements.DisplayText = "doc135.txt";
     activity.ActivationUri = new Uri("my-app://docs/doc135.txt");
 
     // Save the activity


### PR DESCRIPTION
Fixed a small issue in the code sample related to activity publishing for the Recall.

The UserActivity doesn't have DisplayText property.

The DisplayText is a property that is in the VisualElements property of the UserActivity type.

https://learn.microsoft.com/en-us/uwp/api/windows.applicationmodel.useractivities.useractivity.visualelements?view=winrt-26100#windows-applicationmodel-useractivities-useractivity-visualelements

https://learn.microsoft.com/en-us/uwp/api/windows.applicationmodel.useractivities.useractivity?view=winrt-26100