### PR TITLE
Add hint on version check for imaging APIs

### DIFF
--- a/docs/apis/imaging.md
+++ b/docs/apis/imaging.md
@@ -21,6 +21,16 @@ For **API details**, see [API ref for AI imaging features](/windows/windows-app-
 
 For **content moderation details**, see  [Content safety with generative AI APIs](content-moderation.md).
 
+> [!IMPORTANT]
+> **Package Manifest Requirements**: To use Windows AI imaging APIs, your app must be packaged as an MSIX package with the `systemAIModels` capability declared in your `Package.appxmanifest`. Additionally, ensure your manifest's `MaxVersionTested` attribute is set to a recent Windows version (e.g., `10.0.26226.0` or later) to properly support the Windows AI features. Using older values may cause "Not declared by app" errors when loading the model.
+>
+> ```xml
+> <Dependencies>
+>   <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+>   <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26226.0" />
+> </Dependencies>
+> ```
+
 ## What can I do with Image Super Resolution?
 
 The Image Super Resolution APIs enable image sharpening and scaling.


### PR DESCRIPTION
We encountered a vague error when trying to add AI feature on an existing legacy app. It turned out the root cause is an out of dated MaxVersionTested. Therefore's we'd like to add this version check hint in the API doc.