### PR TITLE
Update the "migrating to WinML page"

### DIFF
--- a/docs/new-windows-ml/includes/csharp-tensors-issue.md
+++ b/docs/new-windows-ml/includes/csharp-tensors-issue.md
@@ -1,2 +1,0 @@
-> [!IMPORTANT]
-> C# projects that use the `Microsoft.ML.OnnxRuntime.Tensors` APIs must manually reference the [System.Numerics.Tensors](https://www.nuget.org/packages/System.Numerics.Tensors) NuGet package, version 9.0.0 or greater. Without this NuGet package reference, your code will experience the following runtime error: `Could not load file or assembly 'System.Numerics.Tensors, Version=9.0.0.0`.

--- a/docs/new-windows-ml/migrate-to-windows-ml.md
+++ b/docs/new-windows-ml/migrate-to-windows-ml.md
@@ -50,6 +50,8 @@ For C++ developers, there are two choices...
 
 See [Use ONNX APIs](./use-onnx-apis.md) for more info on both options.
 
+It’s possible that removing the copy of the ONNX Runtime that you’re using isn’t an option, especially if you rely on custom changes made to your copy of the ONNX runtime. In such cases, refer to [using multiple processes](./multiple-processes.md) for more guidance.
+
 ## Step 5: Initialize EPs via Windows ML
 
 See the [initialize execution providers with Windows ML](./initialize-execution-providers.md) docs to learn how to dynamically initialize (download and register) EPs using Windows ML.

--- a/docs/new-windows-ml/migrate-to-windows-ml.md
+++ b/docs/new-windows-ml/migrate-to-windows-ml.md
@@ -41,8 +41,6 @@ Remove the copy of the ONNX Runtime your app is currently using.
 
 Then, follow Step 1 of the [get started with Windows ML](./get-started.md) docs to learn how to install the Windows App SDK (which contains Windows ML).
 
-[!INCLUDE [C# tensors issue](./includes/csharp-tensors-issue.md)]
-
 After installing Windows ML, C# and Python devs should be able to compile their app. The ONNX APIs in Windows ML are identical to the ONNX APIs in standalone ONNX Runtime. See [use ONNX APIs in Windows ML](./use-onnx-apis.md) for more info.
 
 For C++ developers, there are two choices...

--- a/docs/new-windows-ml/multiple-processes.md
+++ b/docs/new-windows-ml/multiple-processes.md
@@ -35,6 +35,4 @@ process.BeginOutputReadLine();
 process.WaitForExit();
 ```
 
-
-
-This method is effective for executing a model a single time which accepts a string as input and produces strings as output. For scenarios that require a persistent AI worker process or the exchange of data types other than strings, Windows offers a variety of [interprocess communication mechanisms](https://learn.microsoft.com/en-us/windows/win32/ipc/interprocess-communications) to support these needs.
+This method is effective for executing a model a single time which accepts a string as input and produces strings as output. For scenarios that require a persistent AI worker process or the exchange of data types other than strings, Windows offers a variety of [interprocess communication mechanisms](/windows/win32/ipc/interprocess-communications) to support these needs.

--- a/docs/new-windows-ml/multiple-processes.md
+++ b/docs/new-windows-ml/multiple-processes.md
@@ -1,0 +1,40 @@
+---
+title: Manage multiple instances of the ONNX Runtime
+description: Learn how to use multiple copies of the ONNX runtime in your application
+ms.date: 12/19/2025
+ms.topic: how-to
+---
+
+# Managing multiple instances of the ONNX Runtime
+
+Sometimes, updating your app to use WinML’s ORT isn’t practical, for example if you rely on custom changes made to your ORT. In such cases, when you use WinML to add new AI features to your application, you’ll want to run WinML in a separate process.
+
+As an example on how to do this, say you wanted to take advantage of WinML’s ability to run SqueezeNet. You would first build the [sample](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/WindowsML/cs/CSharpConsoleDesktop)
+
+This sample accepts an image file as a command-line argument and outputs its interpretation of the image contents.
+
+Within your own application code, you can launch that process, collect its output, and use it in your app.
+
+### [C#](#tab/csharp)
+```csharp
+// Spin up another process which uses Windows ML
+var process = new System.Diagnostics.Process();
+process.StartInfo.FileName = @"CSharpConsoleDesktop.exe";
+process.StartInfo.Arguments = "--ep_policy CPU –image_path myimage.jpg");
+process.StartInfo.RedirectStandardOutput = true;
+process.StartInfo.UseShellExecute = false;
+process.StartInfo.CreateNoWindow = true;
+
+process.OutputDataReceived += (sender, e) =>
+{
+    // parse output
+};
+
+process.Start();
+process.BeginOutputReadLine();
+process.WaitForExit();
+```
+
+
+
+This method is effective for executing a model a single time which accepts a string as input and produces strings as output. For scenarios that require a persistent AI worker process or the exchange of data types other than strings, Windows offers a variety of [interprocess communication mechanisms](https://learn.microsoft.com/en-us/windows/win32/ipc/interprocess-communications) to support these needs.


### PR DESCRIPTION
Removes the comment on System.Numerics.Tensors, as that issue has since been resolved.

Adds comments on how to use multiple versions of ORT in an app at the same time.