### PR TITLE
Add native C/C++ integration docs for Windows ML

### DIFF
--- a/docs/TOC.yml
+++ b/docs/TOC.yml
@@ -105,6 +105,8 @@ items:
                 href: ./new-windows-ml/model-catalog/get-started.md
               - name: Source schema
                 href: ./new-windows-ml/model-catalog/model-catalog-source.md
+          - name: Native C++ integration
+            href: ./new-windows-ml/native-integration.md
           - name: Deploy your app
             href: ./new-windows-ml/distributing-your-app.md
           - name: Migrate to Windows ML

--- a/docs/new-windows-ml/api-reference.md
+++ b/docs/new-windows-ml/api-reference.md
@@ -1,7 +1,7 @@
 ---
 title: Windows ML APIs
 description: Learn about the APIs behind Windows Machine Learning (ML) which help your Windows apps run AI models locally.
-ms.date: 09/26/2025
+ms.date: 02/05/2026
 ms.topic: article
 ---
 
@@ -9,14 +9,19 @@ ms.topic: article
 
 For conceptual guidance, see [Run ONNX models with Windows ML)](./run-onnx-models.md).
 
-You can think of the APIs in the *Microsoft.WindowsAppSDK.ML* NuGet package as being the superset of these two sets:
+You can think of the Windows ML APIs as the combination of these three sets:
 
-* *Windows ML APIs*. Windows ML APIs in the **[Microsoft.Windows.AI.MachineLearning](/windows/windows-app-sdk/api/winrt/microsoft.windows.ai.machinelearning)** namespace, such as the **[ExecutionProviderCatalog](/windows/windows-app-sdk/api/winrt/microsoft.windows.ai.machinelearning.executionprovidercatalog)** class and its methods (which are Windows Runtime APIs).
-* *ONNX Runtime APIs*. Windows ML implementations (in the *Microsoft.WindowsAppSDK.ML* NuGet package) of certain APIs from the ONNX Runtime (ORT). For documentation, see the [ONNX Runtime API docs](https://onnxruntime.ai/docs/api/). For example, the [OrtCompileApi struct](https://onnxruntime.ai/docs/api/c/struct_ort_compile_api.html). For code examples that use these APIs, and more links to documentation, see the [Use Windows ML to run the ResNet-50 model](./tutorial.md) tutorial.
+* *Windows ML WinRT APIs*. Windows Runtime APIs in the **[Microsoft.Windows.AI.MachineLearning](/windows/windows-app-sdk/api/winrt/microsoft.windows.ai.machinelearning)** namespace, such as the **[ExecutionProviderCatalog](/windows/windows-app-sdk/api/winrt/microsoft.windows.ai.machinelearning.executionprovidercatalog)** class and its methods. Available through the *Microsoft.WindowsAppSDK.ML* NuGet package or a pywinrt wheel.
+* *Windows ML C API*. A handle-based C API defined in `WinMLEpCatalog.h` that provides EP discovery, download, and registration without any Windows Runtime dependency. Available through the *Microsoft.WindowsAppSDK.ML* NuGet package or the `microsoft-windows-ai-machinelearning` vcpkg port. See [Use Windows ML without Windows App SDK](./native-integration.md) for details.
+* *ONNX Runtime APIs*. Windows ML implementations of certain APIs from the ONNX Runtime (ORT). For documentation, see the [ONNX Runtime API docs](https://onnxruntime.ai/docs/api/). For example, the [OrtCompileApi struct](https://onnxruntime.ai/docs/api/c/struct_ort_compile_api.html). For code examples that use these APIs, and more links to documentation, see the [Use Windows ML to run the ResNet-50 model](./tutorial.md) tutorial.
 
 ## The Microsoft.WindowsAppSDK.ML NuGet package
 
-The Microsoft Windows ML runtime provides APIs for machine learning and AI operations in Windows applications. The *Microsoft.WindowsAppSDK.ML* NuGet package provides the Windows ML runtime `.winmd` files for use in both C# and C++ projects.
+The Microsoft Windows ML runtime provides APIs for machine learning and AI operations in Windows applications. The *Microsoft.WindowsAppSDK.ML* NuGet package provides the Windows ML runtime `.winmd` files for use in C# and C++/WinRT projects, the C API header `WinMLEpCatalog.h` for native C/C++ projects, and the ONNX Runtime headers and libraries.
+
+## The microsoft-windows-ai-machinelearning vcpkg port
+
+For native C/C++ projects that do not use the Windows App SDK, the `microsoft-windows-ai-machinelearning` vcpkg port provides the Windows ML C API header, ONNX Runtime headers, and runtime binaries. The port exposes a CMake target `Microsoft::Windows::AI::MachineLearning` and a helper function `winml_copy_runtime_dlls()` for copying runtime DLLs to your build output. See [Use Windows ML without Windows App SDK](./native-integration.md) for setup instructions.
 
 ## The pywinrt Python wheels
 
@@ -28,19 +33,23 @@ For API reference documentation, and code examples, see the **[Microsoft.Windows
 
 ## Implementation notes
 
-The Windows ML runtime is integrated with the Windows App SDK and relies on its deployment and bootstrapping mechanisms:
+The Windows ML runtime:
 
 * Automatically discovers execution providers compatible with current hardware
 * Manages package lifetime and updates
 * Handles package registration and activation
 * Supports different versions of execution providers
 
-#### Framework-dependent deployment
+#### Framework-dependent deployment (Windows App SDK)
 
-Windows ML is delivered as a _framework-dependent_ component. This means your app must either:
+When using the Windows App SDK, Windows ML is delivered as a _framework-dependent_ component. This means your app must either:
 
 * Reference the main Windows App SDK NuGet package by adding a reference to `Microsoft.WindowsAppSDK` (recommended)
 * Or, reference both `Microsoft.WindowsAppSDK.ML` and `Microsoft.WindowsAppSDK.Runtime`
+
+#### Self-contained deployment (vcpkg or NuGet redist)
+
+For native C/C++ applications that do not use the Windows App SDK, add the `microsoft-windows-ai-machinelearning` vcpkg port or reference the `Microsoft.WindowsAppSDK.ML` NuGet package directly. Runtime DLLs are deployed alongside your application. See [Deploying your app](./distributing-your-app.md) and [Use Windows ML without Windows App SDK](./native-integration.md) for details.
 
 For more information on deploying Windows App SDK applications, see the [Package and deploy Windows apps](/windows/apps/package-and-deploy/deploy-overview) documentation.
 

--- a/docs/new-windows-ml/distributing-your-app.md
+++ b/docs/new-windows-ml/distributing-your-app.md
@@ -1,17 +1,17 @@
 ---
 title: Deploy your app that uses Windows ML
 description: Learn how to deploy your app that uses Windows Machine Learning (ML).
-ms.date: 07/07/2025
+ms.date: 02/05/2026
 ms.topic: concept-article
 ---
 
 # Deploy your app that uses Windows ML
 
-When you're ready to distribute your C# or C++ app that uses Windows ML, you need to ensure that the Windows App SDK framework is properly deployed to your users' devices. The Windows ML runtime is distributed as part of the Windows App SDK.
+When you're ready to distribute your app that uses Windows ML, you need to ensure that the runtime is properly deployed to your users' devices. Windows ML supports both Windows App SDK and self-contained deployment models.
 
-## Supported deployment options for Windows ML
+## Deployment options with the Windows App SDK
 
-Windows ML supports both the framework-dependent and the self-contained deployment options in Windows App SDK. See the [Windows App SDK deployment overview](/windows/apps/package-and-deploy/deploy-overview) for more details about the deployment options in Windows App SDK.
+If your app uses the Windows App SDK, Windows ML supports both the framework-dependent and the self-contained deployment options. See the [Windows App SDK deployment overview](/windows/apps/package-and-deploy/deploy-overview) for more details.
 
 ### Framework-dependent: ✅ Supported
 
@@ -31,6 +31,30 @@ MyApp/
 ├── onnxruntime_providers_shared.dll
 └── DirectML.dll
 ```
+
+## Self-contained deployment (without Windows App SDK): ✅ Supported
+
+For native C/C++ middleware, game engines, and cross-platform applications, Windows ML can be consumed via [vcpkg](./native-integration.md) or the `Microsoft.WindowsAppSDK.ML` NuGet package without any Windows App SDK dependency. Runtime DLLs are bundled alongside your application or library.
+
+```
+MyApp/
+├── MyApp.exe (or MyPlugin.dll)
+├── Microsoft.Windows.AI.MachineLearning.dll
+├── onnxruntime.dll
+├── onnxruntime_providers_shared.dll
+└── DirectML.dll
+```
+
+With self-contained deployment:
+
+- No Windows App SDK framework installation is required on the target machine.
+- You manage runtime updates through vcpkg or NuGet package updates.
+- EP discovery and download is handled by the Windows ML C API (`WinMLEpCatalog.h`).
+
+For setup instructions, see [Use Windows ML without Windows App SDK](./native-integration.md).
+
+> [!NOTE]
+> If your application already bootstraps the Windows App SDK, vcpkg and NuGet redist consumers can also use the framework package's runtime DLLs without bundling them locally. For details, see [Using with Windows App SDK framework-dependent apps](./native-integration.md#using-with-windows-app-sdk-framework-dependent-apps).
 
 ## Additional resources
 

--- a/docs/new-windows-ml/get-started.md
+++ b/docs/new-windows-ml/get-started.md
@@ -1,7 +1,7 @@
 ---
 title: Get started with Windows ML
 description: Learn how to use Windows ML to download and register AI execution providers for hardware-optimized inference.
-ms.date: 08/13/2025
+ms.date: 02/05/2026
 ms.topic: how-to
 ---
 
@@ -9,7 +9,10 @@ ms.topic: how-to
 
 This topic shows you how to install and use Windows ML to discover, download, and register execution providers (EPs) for use with the ONNX Runtime shipped with Windows ML. Windows ML handles the complexity of package management and hardware selection, automatically downloading the latest execution providers compatible with your device's hardware.
 
-If you're not already familiar with the ONNX Runtime, we suggest reading the [ONNX Runtime docs](https://onnxruntime.ai/docs/). In short, Windows ML provides a shared Windows-wide copy of the ONNX Runtime, plus the ability to dynamically download execution providers (EPs).
+If you're not already familiar with the ONNX Runtime, we suggest reading the [ONNX Runtime docs](https://onnxruntime.ai/docs/). In short, Windows ML provides the ONNX Runtime plus the ability to dynamically download execution providers (EPs).
+
+> [!TIP]
+> Building a native C or C++ application, middleware library, or game engine without the Windows App SDK? See [Use Windows ML without Windows App SDK](./native-integration.md) for a setup guide using vcpkg and the Windows ML C API.
 
 ## Prerequisites
 
@@ -100,6 +103,52 @@ winrt::Microsoft::Windows::AI::MachineLearning::ExecutionProviderCatalog catalog
 // Ensure and register all compatible execution providers with ONNX Runtime
 catalog.EnsureAndRegisterCertifiedAsync().get();
 ```
+
+### [C++](#tab/cpp)
+
+```cpp
+#include <WinMLEpCatalog.h>
+#include <onnxruntime_cxx_api.h>
+#include <string>
+
+// First we need to create an ORT environment
+Ort::Env env(ORT_LOGGING_LEVEL_ERROR, "WinMLDemo");
+
+// Create a Windows ML EP catalog
+WinMLEpCatalogHandle catalog = nullptr;
+HRESULT hr = WinMLEpCatalogCreate(&catalog);
+
+// Enumerate and ready all certified providers
+BOOL CALLBACK ReadyProvider(WinMLEpHandle ep, const WinMLEpInfo* info, void* context)
+{
+    if (info->certification == WinMLEpCertification_Certified)
+    {
+        WinMLEpEnsureReady(ep);
+
+        // Get library path and register with ORT
+        size_t pathSize = 0;
+        WinMLEpGetLibraryPathSize(ep, &pathSize);
+        if (pathSize > 0)
+        {
+            std::string path(pathSize, '\0');
+            WinMLEpGetLibraryPath(ep, pathSize, path.data(), nullptr);
+
+            auto* pEnv = static_cast<Ort::Env*>(context);
+            const OrtApi* ortApi = OrtGetApiBase()->GetApi(ORT_API_VERSION);
+            OrtStatus* status = ortApi->RegisterExecutionProviderLibrary(
+                *pEnv, info->name, path.c_str());
+            if (status) { ortApi->ReleaseStatus(status); }
+        }
+    }
+    return TRUE;
+}
+
+WinMLEpCatalogEnumProviders(catalog, ReadyProvider, &env);
+WinMLEpCatalogRelease(catalog);
+```
+
+> [!NOTE]
+> The C++ tab above uses the Windows ML C API, which does not require the Windows App SDK. See [Use Windows ML without Windows App SDK](./native-integration.md) for full setup instructions.
 
 ### [Python](#tab/python)
 

--- a/docs/new-windows-ml/initialize-execution-providers.md
+++ b/docs/new-windows-ml/initialize-execution-providers.md
@@ -1,7 +1,7 @@
 ---
 title: Initialize execution providers with Windows ML
 description: Learn advanced topics about downloading and registering AI execution providers using Windows Machine Learning (ML) for hardware-optimized inference.
-ms.date: 08/08/2025
+ms.date: 02/05/2026
 ms.topic: how-to
 ---
 
@@ -36,6 +36,39 @@ winrt::Microsoft::Windows::AI::MachineLearning::ExecutionProviderCatalog catalog
 catalog.EnsureAndRegisterCertifiedAsync().get();
 ```
 
+### [C++](#tab/cpp)
+
+```cpp
+#include <WinMLEpCatalog.h>
+
+WinMLEpCatalogHandle catalog = nullptr;
+WinMLEpCatalogCreate(&catalog);
+
+// Enumerate and ensure all compatible EPs, then register with ORT
+WinMLEpCatalogEnumProviders(catalog, [](const WinMLEpInfo* info, void* ctx) {
+    WinMLEpHandle ep = nullptr;
+    WinMLEpCatalogFindProvider(static_cast<WinMLEpCatalogHandle>(ctx), info->Name, &ep);
+    WinMLEpEnsureReady(ep);
+
+    size_t pathSize = 0;
+    WinMLEpGetLibraryPathSize(ep, &pathSize);
+    std::wstring path(pathSize, L'\0');
+    WinMLEpGetLibraryPath(ep, path.data(), pathSize);
+
+    size_t nameSize = 0;
+    WinMLEpGetNameSize(ep, &nameSize);
+    std::string name(nameSize, '\0');
+    WinMLEpGetName(ep, name.data(), nameSize);
+
+    // Register with ONNX Runtime
+    Ort::GetApi().RegisterExecutionProviderLibrary(name.c_str(), path.c_str());
+    return true; // continue enumeration
+}, catalog);
+```
+
+> [!NOTE]
+> The C++ (native) tab uses the Windows ML C API, which does not require the Windows App SDK. See [Use Windows ML without Windows App SDK](./native-integration.md).
+
 ### [Python](#tab/python)
 
 ```python
@@ -68,6 +101,31 @@ auto catalog = winrt::Microsoft::Windows::AI::MachineLearning::ExecutionProvider
 
 // Register only providers already present on the machine
 catalog.RegisterCertifiedAsync().get();
+```
+
+### [C++](#tab/cpp)
+
+```cpp
+// With the C API, enumerate providers but skip any that are not already present
+WinMLEpCatalogEnumProviders(catalog, [](const WinMLEpInfo* info, void* ctx) {
+    if (info->ReadyState == WinMLEpReadyState_Ready) {
+        WinMLEpHandle ep = nullptr;
+        WinMLEpCatalogFindProvider(static_cast<WinMLEpCatalogHandle>(ctx), info->Name, &ep);
+
+        size_t pathSize = 0;
+        WinMLEpGetLibraryPathSize(ep, &pathSize);
+        std::wstring path(pathSize, L'\0');
+        WinMLEpGetLibraryPath(ep, path.data(), pathSize);
+
+        size_t nameSize = 0;
+        WinMLEpGetNameSize(ep, &nameSize);
+        std::string name(nameSize, '\0');
+        WinMLEpGetName(ep, name.data(), nameSize);
+
+        Ort::GetApi().RegisterExecutionProviderLibrary(name.c_str(), path.c_str());
+    }
+    return true;
+}, catalog);
 ```
 
 ### [Python](#tab/python)
@@ -124,6 +182,26 @@ else
 {
     // All EPs are already present, just register them
     catalog.RegisterCertifiedAsync().get();
+}
+```
+
+### [C++](#tab/cpp)
+
+```cpp
+// With the C API, enumerate providers and check their ready state
+bool needsDownload = false;
+WinMLEpCatalogEnumProviders(catalog, [](const WinMLEpInfo* info, void* ctx) {
+    if (info->ReadyState == WinMLEpReadyState_NotPresent) {
+        *static_cast<bool*>(ctx) = true;
+    }
+    return true;
+}, &needsDownload);
+
+if (needsDownload) {
+    // TODO: There are new EPs, decide how your app wants to handle that
+} else {
+    // All EPs are already present; register them
+    // (use the enumeration + register pattern shown above)
 }
 ```
 
@@ -201,6 +279,29 @@ if (qnnProvider)
         // Register the provider with ONNX Runtime
         bool registered = qnnProvider.TryRegister();
     }
+}
+```
+
+### [C++](#tab/cpp)
+
+```cpp
+WinMLEpHandle qnnEp = nullptr;
+HRESULT hr = WinMLEpCatalogFindProvider(catalog, "QNNExecutionProvider", &qnnEp);
+if (SUCCEEDED(hr) && qnnEp) {
+    // Download required components (if not already present)
+    WinMLEpEnsureReady(qnnEp);
+
+    size_t pathSize = 0;
+    WinMLEpGetLibraryPathSize(qnnEp, &pathSize);
+    std::wstring path(pathSize, L'\0');
+    WinMLEpGetLibraryPath(qnnEp, path.data(), pathSize);
+
+    size_t nameSize = 0;
+    WinMLEpGetNameSize(qnnEp, &nameSize);
+    std::string name(nameSize, '\0');
+    WinMLEpGetName(qnnEp, name.data(), nameSize);
+
+    Ort::GetApi().RegisterExecutionProviderLibrary(name.c_str(), path.c_str());
 }
 ```
 

--- a/docs/new-windows-ml/migrate-to-windows-ml.md
+++ b/docs/new-windows-ml/migrate-to-windows-ml.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate from standalone ONNX Runtime to Windows ML's ONNX Runtime
 description: Learn how to migrate from using the standalone ONNX Runtime to using the ONNX Runtime included in Windows Machine Learning (ML) for hardware-optimized inference.
-ms.date: 08/14/2025
+ms.date: 02/05/2026
 ms.topic: how-to
 ---
 
@@ -31,15 +31,22 @@ See the [ONNX Runtime versions shipped in Windows ML](./onnx-versions.md) docs t
 
 See the [supported execution providers in Windows ML](./supported-execution-providers.md) docs to ensure Windows ML supports the execution providers your app requires. Make any updates to your models or code as necessary.
 
-## Step 3: Check Windows App SDK requirements
+## Step 3: Choose a deployment model
 
-Windows ML supports both the framework-dependent and the self-contained deployment options in Windows App SDK. See the [Windows App SDK deployment overview](/windows/apps/package-and-deploy/deploy-overview) for more details about the deployment options in Windows App SDK. Make any updates to your app as necessary.
+Windows ML supports two deployment models:
+
+* **Windows App SDK (framework-dependent)** — the recommended choice for C#, Python, and C++/WinRT applications. See the [Windows App SDK deployment overview](/windows/apps/package-and-deploy/deploy-overview) for details.
+* **Self-contained (vcpkg or NuGet redist)** — for native C/C++ applications that do not use the Windows App SDK. See [Use Windows ML without Windows App SDK](./native-integration.md).
+
+Make any updates to your app as necessary.
 
 ## Step 4: Switch to Windows ML's ONNX Runtime
 
 Remove the copy of the ONNX Runtime your app is currently using.
 
-Then, follow Step 1 of the [get started with Windows ML](./get-started.md) docs to learn how to install the Windows App SDK (which contains Windows ML).
+**If you chose the Windows App SDK path**, follow Step 1 of the [get started with Windows ML](./get-started.md) docs to learn how to install the Windows App SDK (which contains Windows ML).
+
+**If you chose the self-contained path**, install the `microsoft-windows-ai-machinelearning` vcpkg port and follow the setup in [Use Windows ML without Windows App SDK](./native-integration.md).
 
 After installing Windows ML, C# and Python devs should be able to compile their app. The ONNX APIs in Windows ML are identical to the ONNX APIs in standalone ONNX Runtime. See [use ONNX APIs in Windows ML](./use-onnx-apis.md) for more info.
 

--- a/docs/new-windows-ml/native-integration.md
+++ b/docs/new-windows-ml/native-integration.md
@@ -1,0 +1,247 @@
+---
+title: Use Windows ML without Windows App SDK
+description: Learn how to use Windows ML in native C++ applications, middleware, and game engines without requiring the Windows App SDK, using vcpkg and the Windows ML C API.
+ms.date: 02/05/2026
+ms.topic: how-to
+---
+
+# Use Windows ML without Windows App SDK
+
+Windows ML can be used in native C and C++ applications without any dependency on the Windows App SDK. This is ideal for middleware libraries, game engines, audio plugins, and cross-platform codebases that need to discover and use hardware-accelerated execution providers (EPs) on Windows.
+
+The Windows ML C API (`WinMLEpCatalog.h`) provides EP discovery and acquisition using familiar C conventions: UTF-8 strings, HRESULT error codes, and callback-based patterns. After discovering EPs, you use the standard [ONNX Runtime C API](https://onnxruntime.ai/docs/api/) for model inference.
+
+## When to use this approach
+
+Use the Windows ML C API and vcpkg distribution when:
+
+- Your codebase is C or C++ without C++/WinRT
+- You're building cross-platform middleware with a Windows backend
+- You need to minimize binary size and external dependencies
+- You're shipping a plugin (for example, audio, video) that runs inside a host application you don't control
+- Your build system uses CMake or another non-MSBuild toolchain
+
+## Prerequisites
+
+- Windows 11 (version 24H2, build 26100 or later)
+- Visual Studio 2022 with C++ workload
+- CMake 3.20 or later
+- [vcpkg](https://vcpkg.io) (or the NuGet package `Microsoft.WindowsAppSDK.ML`)
+
+## Step 1: Install the vcpkg package
+
+The `microsoft-windows-ai-machinelearning` vcpkg port provides the Windows ML C API header, ONNX Runtime headers and libraries, and the runtime DLLs.
+
+```powershell
+vcpkg install microsoft-windows-ai-machinelearning
+```
+
+In your `CMakeLists.txt`:
+
+```cmake
+cmake_minimum_required(VERSION 3.20)
+project(MyApp LANGUAGES CXX)
+
+find_package(microsoft-windows-ai-machinelearning CONFIG REQUIRED)
+
+add_executable(MyApp main.cpp)
+target_link_libraries(MyApp PRIVATE Microsoft::Windows::AI::MachineLearning)
+
+# Copy runtime DLLs to the output directory
+winml_copy_runtime_dlls(MyApp)
+```
+
+Build with:
+
+```powershell
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE="path/to/vcpkg/scripts/buildsystems/vcpkg.cmake"
+cmake --build build --config Release
+```
+
+> [!TIP]
+> You can also consume Windows ML from the `Microsoft.WindowsAppSDK.ML` NuGet package directly. The NuGet package includes the same headers, import libraries, and CMake config files as the vcpkg port.
+
+## Step 2: Discover and prepare execution providers
+
+Use the Windows ML C API to discover which execution providers are available for the current hardware and ensure they are ready to use.
+
+```cpp
+#include <WinMLEpCatalog.h>
+#include <iostream>
+#include <string>
+
+int main()
+{
+    // Create a catalog handle
+    WinMLEpCatalogHandle catalog = nullptr;
+    HRESULT hr = WinMLEpCatalogCreate(&catalog);
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    // Find a provider by name (NULL = any certified package)
+    WinMLEpHandle ep = nullptr;
+    hr = WinMLEpCatalogFindProvider(catalog, "QNN", NULL, &ep);
+    if (FAILED(hr))
+    {
+        std::cerr << "QNN provider not found (0x" << std::hex << hr << ")" << std::endl;
+        WinMLEpCatalogRelease(catalog);
+        return hr;
+    }
+
+    // Ensure the provider is ready (downloads if needed)
+    hr = WinMLEpEnsureReady(ep);
+    if (FAILED(hr))
+    {
+        std::cerr << "Failed to ready provider (0x" << std::hex << hr << ")" << std::endl;
+        WinMLEpCatalogRelease(catalog);
+        return hr;
+    }
+
+    // Get the library path for ONNX Runtime registration
+    size_t pathSize = 0;
+    WinMLEpGetLibraryPathSize(ep, &pathSize);
+
+    std::string libraryPath(pathSize, '\0');
+    WinMLEpGetLibraryPath(ep, pathSize, libraryPath.data(), nullptr);
+
+    std::cout << "Provider ready at: " << libraryPath << std::endl;
+
+    WinMLEpCatalogRelease(catalog);
+    return 0;
+}
+```
+
+### Enumerating all providers
+
+To discover all available providers, use the callback-based enumeration API:
+
+```cpp
+#include <WinMLEpCatalog.h>
+#include <iostream>
+
+BOOL CALLBACK PrintProvider(WinMLEpHandle ep, const WinMLEpInfo* info, void* context)
+{
+    std::cout << "Provider: " << info->name << " (v" << info->version << ")" << std::endl;
+    std::cout << "  Ready: "
+              << (info->readyState == WinMLEpReadyState_Ready ? "Yes" :
+                  info->readyState == WinMLEpReadyState_NotReady ? "No" : "Not present")
+              << std::endl;
+    return TRUE; // Continue enumeration
+}
+
+// Usage:
+// WinMLEpCatalogEnumProviders(catalog, PrintProvider, nullptr);
+```
+
+## Step 3: Register with ONNX Runtime and run inference
+
+After getting the EP library path from Windows ML, register it with ONNX Runtime and create an inference session:
+
+```cpp
+#include <WinMLEpCatalog.h>
+#include <onnxruntime_cxx_api.h>
+#include <string>
+
+int main()
+{
+    // Initialize ONNX Runtime
+    Ort::Env env(ORT_LOGGING_LEVEL_ERROR, "MyApp");
+
+    // --- Windows ML: discover and prepare EP ---
+    WinMLEpCatalogHandle catalog = nullptr;
+    WinMLEpCatalogCreate(&catalog);
+
+    WinMLEpHandle ep = nullptr;
+    HRESULT hr = WinMLEpCatalogFindProvider(catalog, "QNN", NULL, &ep);
+    if (SUCCEEDED(hr))
+    {
+        WinMLEpEnsureReady(ep);
+
+        size_t pathSize = 0;
+        WinMLEpGetLibraryPathSize(ep, &pathSize);
+        std::string libraryPath(pathSize, '\0');
+        WinMLEpGetLibraryPath(ep, pathSize, libraryPath.data(), nullptr);
+
+        // Register the EP with ONNX Runtime
+        const OrtApi* ortApi = OrtGetApiBase()->GetApi(ORT_API_VERSION);
+        OrtStatus* status = ortApi->RegisterExecutionProviderLibrary(
+            env, "QNN", libraryPath.c_str());
+        if (status)
+        {
+            ortApi->ReleaseStatus(status);
+        }
+    }
+
+    WinMLEpCatalogRelease(catalog);
+
+    // --- ONNX Runtime: create session and run inference ---
+    Ort::SessionOptions sessionOptions;
+    Ort::Session session(env, L"model.onnx", sessionOptions);
+
+    // ... run inference using standard ONNX Runtime APIs ...
+
+    return 0;
+}
+```
+
+## Handle ownership model
+
+All provider handles (`WinMLEpHandle`) are owned by the catalog and remain valid until you call `WinMLEpCatalogRelease`. You don't need to release individual provider handles.
+
+## Deployment
+
+### Self-contained deployment
+
+By default, include the runtime DLLs alongside your executable:
+
+```
+MyApp/
+├── MyApp.exe
+├── Microsoft.Windows.AI.MachineLearning.dll
+├── onnxruntime.dll
+├── onnxruntime_providers_shared.dll
+└── DirectML.dll
+```
+
+If you use CMake with the vcpkg port, the `winml_copy_runtime_dlls` function handles copying these DLLs to your output directory automatically. You manage runtime updates through vcpkg or NuGet package updates.
+
+### Using with Windows App SDK framework-dependent apps
+
+If your application already bootstraps the Windows App SDK (via `MddBootstrapInitialize` or MSIX package identity), you can use the vcpkg port **without bundling the runtime DLLs**. The Windows App SDK framework package already contains `onnxruntime.dll`, `DirectML.dll`, and the other runtime binaries.
+
+On Windows 11 (version 21H2, build 22000 and later), the [DLL search order](/windows/win32/dlls/dynamic-link-library-search-order) includes the process's **package dependency graph** — the set of framework packages added at bootstrap or declared in the app's package manifest. When the vcpkg port's import library triggers a load of `onnxruntime.dll`, Windows resolves it from the framework package automatically. No auto-initializer, CMake configuration changes, or additional NuGet packages are required.
+
+To use this approach, omit the `winml_copy_runtime_dlls` call in your `CMakeLists.txt`:
+
+```cmake
+find_package(microsoft-windows-ai-machinelearning CONFIG REQUIRED)
+
+add_executable(MyApp main.cpp)
+target_link_libraries(MyApp PRIVATE WindowsML::Api WindowsML::OnnxRuntime)
+
+# Do not call winml_copy_runtime_dlls — DLLs resolve from the framework package
+```
+
+> [!NOTE]
+> This approach requires the Windows App SDK framework package to be present on the target machine. For apps that don't use the Windows App SDK, use [self-contained deployment](#self-contained-deployment) instead.
+
+## Comparison with Windows App SDK
+
+| | Windows App SDK | Self-contained (vcpkg / NuGet redist) |
+|--|--|--|
+| **API** | WinRT (`ExecutionProviderCatalog`) and C API | C API (`WinMLEpCatalog.h`) |
+| **Languages** | C#, C++/WinRT, Python | C, C++ |
+| **Build system** | MSBuild, NuGet | CMake, vcpkg, NuGet |
+| **Runtime updates** | Automatic via shared framework | Manual via package updates |
+| **Windows App SDK dependency** | Yes (framework-dependent) or optional (self-contained) | None (or optional — see [framework-dependent apps](#using-with-windows-app-sdk-framework-dependent-apps)) |
+| **Best for** | Windows apps (WinUI, WPF, console) | Middleware, plugins, game engines, cross-platform libraries |
+
+## See also
+
+- [Get started with Windows ML](./get-started.md) — for Windows App SDK users
+- [Supported execution providers](./supported-execution-providers.md)
+- [Initialize execution providers](./initialize-execution-providers.md) — WinRT API patterns
+- [Deploying your app](./distributing-your-app.md) — all deployment options
+- [ONNX Runtime documentation](https://onnxruntime.ai/docs/)

--- a/docs/new-windows-ml/overview.md
+++ b/docs/new-windows-ml/overview.md
@@ -2,7 +2,7 @@
 title: What is Windows ML?
 description: Learn how Windows Machine Learning (ML) helps your Windows apps run AI models locally.
 ms.topic: article
-ms.date: 11/18/2025
+ms.date: 02/05/2026
 ---
 
 # What is Windows ML?
@@ -11,20 +11,22 @@ Windows Machine Learning (ML) enables C#, C++, and Python developers to run ONNX
 
 :::image type="content" source="../images/winml-diagram.png" alt-text="A diagram illustrating an ONNX model going through Windows ML to then reach NPUs, GPUs, and CPUs.":::
 
-If you're not already familiar with the ONNX Runtime, we suggest reading the [ONNX Runtime docs](https://onnxruntime.ai/docs/). In short, Windows ML provides a shared Windows-wide copy of the ONNX Runtime, plus the ability to dynamically download execution providers (EPs).
+If you're not already familiar with the ONNX Runtime, we suggest reading the [ONNX Runtime docs](https://onnxruntime.ai/docs/). In short, Windows ML provides the ONNX Runtime plus the ability to dynamically download execution providers (EPs). You can use Windows ML through the Windows App SDK (shared framework runtime), or self-contained via vcpkg or NuGet for native C/C++ projects.
 
 ## Key benefits
 
 - **Dynamically get latest EPs** - Automatically downloads and manages the latest hardware-specific execution providers
-- **Shared [ONNX Runtime](https://onnxruntime.ai/docs/)** - Uses system-wide runtime instead of bundling your own, reducing app size
-- **Smaller downloads/installs** - No need to carry large EPs and the ONNX Runtime in your app
+- **Flexible deployment** - Use a shared system-wide runtime via the Windows App SDK for smaller app size, or bundle the runtime with your app for self-contained deployment
+- **Smaller downloads/installs** - No need to carry large EPs in your app; Windows ML downloads them on demand
 - **Broad hardware support** - Runs on Windows PCs (x64 and ARM64) and Windows Server with any hardware configuration
+- **Native C/C++ support** - Use the [Windows ML C API](./native-integration.md) for middleware, game engines, and cross-platform native code without Windows App SDK dependencies
 
 ## System requirements
 
-- **OS**: Version of Windows that [Windows App SDK supports](/windows/apps/windows-app-sdk/support)
 - **Architecture**: x64 or ARM64
 - **Hardware**: Any PC configuration (CPUs, integrated/discrete GPUs, NPUs)
+- **OS for Windows App SDK distribution**: Version of Windows that [Windows App SDK supports](/windows/apps/windows-app-sdk/support)
+- **OS for self-contained deployment (vcpkg / NuGet redist)**: Windows 11 version 24H2 (build 26100) or later
 
 > [!NOTE]
 > Support for CPU and GPU (via DirectML) is available on all supported Windows versions. Vendor-optimized execution providers for NPUs and specific GPU hardware require Windows 11 version 24H2 (build 26100) or greater. For detail, see [Supported execution providers](./supported-execution-providers.md).
@@ -39,9 +41,9 @@ You can [see the list of EPs that Windows ML supports here](./supported-executio
 
 Windows ML includes a copy of the [ONNX Runtime](https://onnxruntime.ai/) and allows you to dynamically download vendor-specific **execution providers** (EPs), so your model inference can be optimized across the wide variety of CPUs, GPUs, and NPUs in the Windows ecosystem.
 
-### Automatic deployment
+### Automatic deployment (Windows App SDK)
 
-1. **App installation** - Windows App SDK bootstrapper initializes Windows ML
+1. **App installation** - Windows App SDK framework initializes Windows ML
 2. **Hardware detection** - Runtime identifies available processors  
 3. **EP download** - Automatically downloads optimal execution providers
 4. **Ready to run** - Your app can immediately use AI models

--- a/docs/new-windows-ml/samples.md
+++ b/docs/new-windows-ml/samples.md
@@ -32,7 +32,8 @@ The [Windows App SDK Samples repository on GitHub](https://github.com/microsoft/
 | C# | WinUI | MSIX | Framework-dependent | [Link](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/WindowsML/cs-winui) |
 | C# | WinForms | Unpackaged | Framework-dependent | [Link](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/WindowsML/cs-winforms) |
 | C++ | Console | DLL w/ separate EXE | Framework-dependent | [Link](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/WindowsML/cpp/CppConsoleDll) |
-| C++ | Console | Unpackaged | Self-contained | [Link](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/WindowsML/cpp/CppConsoleDesktop.SelfContained) |
+| C++ | Console | Unpackaged | Self-contained (Windows App SDK) | [Link](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/WindowsML/cpp/CppConsoleDesktop.SelfContained) |
+| C++ | Console (C API) | Unpackaged | Self-contained (vcpkg) | [Link](./native-integration.md) |
 | C++ | Console | MSIX | Framework-dependent | [Link](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/WindowsML/cpp/CppConsoleDesktop.FrameworkDependent) |
 | Python | Console | Unpackaged | Framework-dependent | [Link](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/WindowsML/python) |
 

--- a/docs/new-windows-ml/use-onnx-apis.md
+++ b/docs/new-windows-ml/use-onnx-apis.md
@@ -1,13 +1,13 @@
 ---
 title: Use ONNX APIs in Windows ML
 description: Learn how to use the ONNX APIs shipped in Windows Machine Learning (ML) to use local AI ONNX models in your Windows apps.
-ms.date: 08/13/2025
+ms.date: 02/05/2026
 ms.topic: how-to
 ---
 
 # Use ONNX APIs in Windows ML
 
-Windows Machine Learning (ML) includes a shared copy of the [ONNX Runtime](https://onnxruntime.ai/), including its APIs. That means when you install Windows ML via Windows App SDK, your app will have access to the full ONNX API surface.
+Windows Machine Learning (ML) includes a shared copy of the [ONNX Runtime](https://onnxruntime.ai/), including its APIs. When you install Windows ML via the Windows App SDK or the `microsoft-windows-ai-machinelearning` vcpkg port, your app has access to the full ONNX API surface.
 
 To see what version of ONNX Runtime is included in specific Windows ML versions, see [ONNX Runtime versions shipped in Windows ML](./onnx-versions.md).
 
@@ -15,7 +15,7 @@ This page covers how to use the ONNX APIs included in Windows ML.
 
 ## Prerequisites
 
-* Follow all the steps in [Get started with Windows ML](./get-started.md).
+* Follow all the steps in [Get started with Windows ML](./get-started.md), or, for native C/C++ projects, see [Use Windows ML without Windows App SDK](./native-integration.md).
 
 ## Namespaces / headers
 
@@ -31,7 +31,7 @@ using Microsoft.ML.OnnxRuntime;
 
 ### [C++](#tab/cppwinrt)
 
-In C++, the ONNX Runtime headers are included in a `winml/` directory to avoid conflicts with other versions of ONNX Runtime.
+In C++/WinRT, the ONNX Runtime headers are included in a `winml/` directory to avoid conflicts with other versions of ONNX Runtime.
 
 ```cppwinrt
 #include <winml/onnxruntime_cxx_api.h>
@@ -53,6 +53,20 @@ Then, the headers will be the same as standalone ONNX Runtime:
 
 > [!NOTE]
 > In the pre-GA releases of Windows ML, the C++ ONNX Runtime headers were prefixed by `win_` rather than within a `winml/` subdirectory, and the **WinMLEnableDefaultOrtHeaderIncludePath** property didn't exist.
+
+### [C++](#tab/cpp)
+
+With the `microsoft-windows-ai-machinelearning` vcpkg port, include the ONNX Runtime headers directly (no `winml/` prefix required):
+
+```cpp
+#include <onnxruntime_cxx_api.h>
+```
+
+The vcpkg port also provides the Windows ML C API header:
+
+```cpp
+#include <WinMLEpCatalog.h>
+```
 
 
 ### [Python](#tab/python)


### PR DESCRIPTION
Document Windows ML's native-first development path using the flat-C API and vcpkg, independent of Windows App SDK and WinRT.

Changes:
- Add native-integration.md: setup guide for vcpkg and the Windows ML C API (WinMLEpCatalog.h), including deployment options for self-contained and Windows App SDK framework- dependent scenarios (DLL search order / package dependency graph)
- Add [C++] tabs to get-started, initialize-execution-providers, and use-onnx-apis pages with C API code samples
- Update terminology: Self-contained (Windows App SDK) vs Self-contained (vcpkg) to distinguish deployment models
- Update api-reference.md: add C API and vcpkg port sections
- Update distributing-your-app.md: add non-Windows App SDK deployment section with framework-dependent cross-reference
- Update overview.md: add flexible deployment and native C/C++ support
- Update migrate-to-windows-ml.md: add self-contained deployment path
- Update samples.md: add C API sample row
- Add native-integration.md to TOC.yml