### PR TITLE
[Doc] Fix FindAllModelAsync() typo to FindAllModelsAsync()

### DIFF
--- a/docs/new-windows-ml/model-catalog/get-started.md
+++ b/docs/new-windows-ml/model-catalog/get-started.md
@@ -171,14 +171,14 @@ public async Task FilterByExecutionProvidersAsync(ModelCatalog catalog)
     catalog.ExecutionProviders.Clear();
     catalog.ExecutionProviders.Add("cpuexecutionprovider");
     
-    var cpuModels = await catalog.FindAllModelAsync();
+    var cpuModels = await catalog.FindAllModelsAsync();
     Console.WriteLine($"Found {cpuModels.Count} CPU-compatible models");
     
     // Look for DirectML-compatible models
     catalog.ExecutionProviders.Clear();
     catalog.ExecutionProviders.Add("dmlexecutionprovider");
     
-    var dmlModels = await catalog.FindAllModelAsync();
+    var dmlModels = await catalog.FindAllModelsAsync();
     Console.WriteLine($"Found {dmlModels.Count} DirectML-compatible models");
 }
 ```


### PR DESCRIPTION
## Problem
The C# code snippet in the Model Catalog get-started page uses `FindAllModelAsync()` (singular) which doesn't exist. The correct API is `FindAllModelsAsync()` (plural).

## Fix
Changed `FindAllModelAsync()` to `FindAllModelsAsync()` in two places in the `FilterByExecutionProvidersAsync` code sample.

## Files changed
- `docs/new-windows-ml/model-catalog/get-started.md` — Fixed 2 occurrences