### PR TITLE
[Doc] Fix offline note: EPs downloaded via Windows Update, not bundled in NuGet

### DIFF
--- a/docs/new-windows-ml/initialize-execution-providers.md
+++ b/docs/new-windows-ml/initialize-execution-providers.md
@@ -15,6 +15,9 @@ This page covers how to install EPs onto a user's device. Once installed, you'll
 
 For initial development, it can be nice to simply call `EnsureAndRegisterCertifiedAsync()`, which will download and install all EPs available to your user's device, and then registers all EPs with the ONNX Runtime in one single call. Note that on first run, this method can take multiple seconds or even minutes depending on your network speed and EPs that need to be downloaded.
 
+> [!NOTE]
+> **Offline or restricted-network environments:** Execution provider packages are downloaded on first use. For environments without internet access, you can use the self-contained deployment model which bundles execution providers with your application. See [Distributing your app](distributing-your-app.md) for details on self-contained deployment.
+
 ### [C#](#tab/csharp)
 
 ```csharp

--- a/docs/new-windows-ml/initialize-execution-providers.md
+++ b/docs/new-windows-ml/initialize-execution-providers.md
@@ -16,7 +16,7 @@ This page covers how to install EPs onto a user's device. Once installed, you'll
 For initial development, it can be nice to simply call `EnsureAndRegisterCertifiedAsync()`, which will download and install all EPs available to your user's device, and then registers all EPs with the ONNX Runtime in one single call. Note that on first run, this method can take multiple seconds or even minutes depending on your network speed and EPs that need to be downloaded.
 
 > [!NOTE]
-> **Offline or restricted-network environments:** Execution provider packages are downloaded on first use. For environments without internet access, you can use the self-contained deployment model which bundles execution providers with your application. See [Distributing your app](distributing-your-app.md) for details on self-contained deployment.
+> **Offline or restricted-network environments:** Execution provider packages are downloaded on first use via the [Windows Update infrastructure](./execution-provider-errors.md). They are not included in the NuGet package or self-contained deployment. Environments without internet access or with [Windows Updates paused](./execution-provider-errors.md#windows-updates-paused) will not be able to download execution providers.
 
 ### [C#](#tab/csharp)
 


### PR DESCRIPTION
## Problem
The EP initialization page doesn't mention that EP packages are downloaded via Windows Update infrastructure, not bundled in the NuGet package. Developers in restricted-network environments will fail silently.

## Fix
Added a NOTE callout explaining that EP packages are downloaded on first use via Windows Update, are NOT included in NuGet or self-contained deployment, and environments without internet or with paused Windows Updates cannot download them.

## Files changed
- `docs/new-windows-ml/initialize-execution-providers.md`