### PR TITLE
[Doc] Add Olive link and auto-selection info to optimization note

### DIFF
--- a/docs/new-windows-ml/overview.md
+++ b/docs/new-windows-ml/overview.md
@@ -52,7 +52,7 @@ This eliminates the need to:
 - Handle execution provider updates manually
 
 > [!NOTE]
-> You're still responsible for optimizing your models for different hardware. Windows ML handles execution provider distribution, not model optimization. See [AI Toolkit](https://code.visualstudio.com/docs/intelligentapps/modelconversion) and the [ONNX Runtime Tutorials](https://onnxruntime.ai/docs/tutorials/) for more info on optimization.
+> Windows ML automatically selects the best execution provider for your hardware, but you're still responsible for optimizing your models. Combining hardware-aware model optimization with the right execution provider yields the best inference performance. See [AI Toolkit](https://code.visualstudio.com/docs/intelligentapps/modelconversion), [Olive](https://microsoft.github.io/Olive/), and the [ONNX Runtime Tutorials](https://onnxruntime.ai/docs/tutorials/) for more info on model optimization.
 
 ## Performance optimization
 


### PR DESCRIPTION
## Problem
The overview page's NOTE about model optimization only mentions AI Toolkit and ONNX Runtime Tutorials, but omits Olive (Microsoft's official model optimization tool) and doesn't clarify that Windows ML auto-selects the best EP.

## Fix
Rewrote the optimization NOTE to clarify Windows ML auto-selects EPs, and added link to Olive alongside existing AI Toolkit and ORT links.

## Files changed
- `docs/new-windows-ml/overview.md`