### PR TITLE
[Doc] Add error code reference for EP registration results

### DIFF
--- a/docs/new-windows-ml/initialize-execution-providers.md
+++ b/docs/new-windows-ml/initialize-execution-providers.md
@@ -239,6 +239,15 @@ installed = result.status == winml.ExecutionProviderReadyResultState.SUCCESS
 
 ---
 
+### Handling installation results
+
+The [ExecutionProviderReadyResult](/windows/windows-app-sdk/api/winrt/microsoft.windows.ai.machinelearning.executionproviderreadyresult) returned by `EnsureReadyAsync()` includes a [Status](/windows/windows-app-sdk/api/winrt/microsoft.windows.ai.machinelearning.executionproviderreadyresult.status) property of type [ExecutionProviderReadyResultState](/windows/windows-app-sdk/api/winrt/microsoft.windows.ai.machinelearning.executionproviderreadyresultstate). When `Status` is not `Success`, use the `ExtendedError` and `DiagnosticText` properties to diagnose the failure.
+
+> [!TIP]
+> Always check the `Status` before proceeding with session creation. If a provider fails, consider falling back to a different execution provider, such as the CPU execution provider. For common download and installation issues, see [Troubleshoot execution provider download issues](./execution-provider-errors.md).
+
+---
+
 ## Installing with progress
 
 The APIs for downloading and installing EPs include callbacks that provide progress updates, so that you can display progress indicators to keep your users informed.


### PR DESCRIPTION
## Problem
The EP initialization page shows how to call `EnsureReadyAsync()` but doesn't explain how to handle the return value — checking Status, using ExtendedError/DiagnosticText, or falling back to CPU.

## Fix
Added a 'Handling installation results' subsection with API reference links, guidance to check Status before session creation, and a TIP about fallback strategies.

## Files changed
- `docs/new-windows-ml/initialize-execution-providers.md`