### PR TITLE
[Doc] Fix API Reference See also link from experimental to main

### DIFF
--- a/docs/new-windows-ml/api-reference.md
+++ b/docs/new-windows-ml/api-reference.md
@@ -80,6 +80,6 @@ The pywinrt project includes a msvcp140.dll in the winrt-runtime package. This m
 * [Run ONNX models with Windows ML](./run-onnx-models.md)
 * [Windows App SDK Documentation](/windows/apps/windows-app-sdk/)
 * [Windows App SDK on GitHub](https://github.com/microsoft/WindowsAppSDK)
-* [Windows ML Samples](https://github.com/microsoft/WindowsAppSDK-Samples/tree/release/experimental/Samples/WindowsML)
+* [Windows ML Samples](https://github.com/microsoft/WindowsAppSDK-Samples/tree/main/Samples/WindowsML)
 * [ONNX Runtime API Documentation](https://onnxruntime.ai/docs/api/)
 * [Package and deploy Windows apps](/windows/apps/package-and-deploy/deploy-overview)


### PR DESCRIPTION
## Problem
The API Reference page links to Windows ML samples using the stale `release/experimental` branch. Samples are now on `main`.

## Fix
Updated the link from `release/experimental` to `main`.

## Files changed
- `docs/new-windows-ml/api-reference.md`