### PR TITLE
[Doc] Fix C++ thread spinning snippet: AddSessionConfigEntry to AddConfigEntry

### DIFF
--- a/docs/new-windows-ml/run-onnx-models.md
+++ b/docs/new-windows-ml/run-onnx-models.md
@@ -64,8 +64,8 @@ using InferenceSession session = new(modelPath, sessionOptions);
 ```cpp
 // Create session options and enable thread spinning
 Ort::SessionOptions sessionOptions;
-sessionOptions.AddSessionConfigEntry("session.intra_op.allow_spinning", "1");
-sessionOptions.AddSessionConfigEntry("session.inter_op.allow_spinning", "1");
+sessionOptions.AddConfigEntry("session.intra_op.allow_spinning", "1");
+sessionOptions.AddConfigEntry("session.inter_op.allow_spinning", "1");
 
 // Create inference session using our session options
 Ort::Session session(env, modelPath.c_str(), sessionOptions);


### PR DESCRIPTION
## Problem
The C++ thread-spinning code snippet calls `AddSessionConfigEntry()` which doesn't exist in the ONNX Runtime C++ API. The correct method is `AddConfigEntry()`.

## Fix
Changed `AddSessionConfigEntry(...)` to `AddConfigEntry(...)` in 2 places.

## Files changed
- `docs/new-windows-ml/run-onnx-models.md` — C++ tab