### PR TITLE
[Doc] Fix Python thread spinning snippet: AddConfigEntry to add_session_config_entry

### DIFF
--- a/docs/new-windows-ml/run-onnx-models.md
+++ b/docs/new-windows-ml/run-onnx-models.md
@@ -78,8 +78,8 @@ import onnxruntime as ort
 
 # Create session options and enable thread spinning
 options = ort.SessionOptions()
-options.AddConfigEntry("session.intra_op.allow_spinning", "1")
-options.AddConfigEntry("session.inter_op.allow_spinning", "1")
+options.add_session_config_entry("session.intra_op.allow_spinning", "1")
+options.add_session_config_entry("session.inter_op.allow_spinning", "1")
 
 # Create inference session using our session options
 session = ort.InferenceSession(model_path, sess_options=options)


### PR DESCRIPTION
## Problem
The Python thread-spinning snippet calls `AddConfigEntry()` (C++ method name). The correct Python API is `add_session_config_entry()`.

## Fix
Changed `AddConfigEntry(...)` to `add_session_config_entry(...)` in 2 places.

## Files changed
- `docs/new-windows-ml/run-onnx-models.md` — Python tab