### PR TITLE
Fix windows ai code errors

### DIFF
--- a/docs/apis/app-content-search-tutorial.md
+++ b/docs/apis/app-content-search-tutorial.md
@@ -59,6 +59,20 @@ public void SimpleGetOrCreateIndexSample()
 
 This sample shows error handling the failure case for opening an index. For simplicity, other samples in this document may not show error handling.
 
+The following samples use a `GetIndexerForApp` helper method to get or create an index. Here's the implementation:
+
+```csharp
+private AppContentIndexer GetIndexerForApp()
+{
+    var result = AppContentIndexer.GetOrCreateIndex("myindex");
+    if (!result.Succeeded)
+    {
+        throw new InvalidOperationException($"Failed to open index. Status = '{result.Status}', Error = '{result.ExtendedError}'");
+    }
+    return result.Indexer;
+}
+```
+
 ## Add text strings to the index and then run a query
 
 This sample demonstrates how to add some text strings to the index created for your app and then run a query against that index to retrieve relevant information.

--- a/docs/apis/app-content-search-tutorial.md
+++ b/docs/apis/app-content-search-tutorial.md
@@ -69,6 +69,7 @@ private AppContentIndexer GetIndexerForApp()
     {
         throw new InvalidOperationException($"Failed to open index. Status = '{result.Status}', Error = '{result.ExtendedError}'");
     }
+    // Caller should dispose the returned indexer when finished (for example: `using var indexer = GetIndexerForApp();`).
     return result.Indexer;
 }
 ```

--- a/docs/apis/get-started.md
+++ b/docs/apis/get-started.md
@@ -386,7 +386,7 @@ The following snippet shows how to check for model availability and generate a r
 1. In Form.cs, replace the **Form** class with the following code, which confirms the [**LanguageModel**](/windows/windows-app-sdk/api/winrt/microsoft.windows.ai.text.languagemodel) is available and then submits a prompt asking for the model to respond with the molecular formula of glucose.
 
     ```csharp
-    public partial class Form1 : Window
+    public partial class Form1 : Form
     {
         public Form1()
         {

--- a/docs/apis/phi-silica-winui-tutorial.md
+++ b/docs/apis/phi-silica-winui-tutorial.md
@@ -250,33 +250,6 @@ public sealed partial class MainWindow : Window
         }
     }
 
-        if (readyState == AIFeatureReadyState.NotReady)
-        {
-            StatusText.Text = "Model not ready — installing. This may take a few minutes...";
-            var ensureResult = await LanguageModel.EnsureReadyAsync();
-
-            if (ensureResult.ExtendedError != null)
-            {
-                StatusText.Text = $"Model installation failed: {ensureResult.ExtendedError.Message}";
-                return;
-            }
-        }
-        else if (readyState == AIFeatureReadyState.NotSupportedOnCurrentSystem)
-        {
-            // This device does not have a compatible NPU or is not a Copilot+ PC.
-            // Consider falling back to Foundry Local or an Azure OpenAI endpoint.
-            StatusText.Text = "Phi Silica is not supported on this device. A Copilot+ PC is required.";
-            ResponseText.Text = "Phi Silica requires a Copilot+ PC with an NPU.\n\n" +
-                                 "For on-device AI on any Windows PC, see Foundry Local:\n" +
-                                 "https://learn.microsoft.com/windows/ai/foundry-local/get-started";
-            return;
-        }
-
-        _languageModel = await LanguageModel.CreateAsync();
-        StatusText.Text = "Model ready.";
-        SendButton.IsEnabled = true;
-    }
-
     private async void OnSendClicked(object sender, RoutedEventArgs e)
     {
         if (_languageModel is null) return;

--- a/docs/apis/text-recognition-tutorial.md
+++ b/docs/apis/text-recognition-tutorial.md
@@ -35,7 +35,7 @@ Some of the more significant functions and event handlers in the [Windows AI API
 
 ### Text recognition example
 
-The `PerformTextRecognition` function in this example
+The `PerformTextRecognition` function in this example calls a `LoadImageBufferFromFileAsync` helper function to load an image file. For the implementation of this helper function, see [Create an ImageBuffer from a file](text-recognition.md#create-an-imagebuffer-from-a-file).
 
 ![The input image.](../images/API-Tutorials-WinFormsimage1_Inputimage_3x.png)
 

--- a/docs/new-windows-ml/tutorial.md
+++ b/docs/new-windows-ml/tutorial.md
@@ -244,17 +244,19 @@ std::filesystem::path modelPathToUse = isCompiledModelAvailable ? compiledModelP
 ### [Python](#tab/python)
 
 ```python
-model_path = "path to your original model"
-compiled_model_path = "path to your compiled model"
+from pathlib import Path
+
+model_path = Path("path to your original model")
+compiled_model_path = Path("path to your compiled model")
 
 if compiled_model_path.exists():
     print("Using compiled model")
 else:
     print("No compiled model found, attempting to create compiled model at ", compiled_model_path)  
-    model_compiler = ort.ModelCompiler(session_options, model_path)
+    model_compiler = ort.ModelCompiler(session_options, str(model_path))
     print("Starting compile, this may take a few moments..." )
     try:
-        model_compiler.compile_to_file(compiled_model_path)
+        model_compiler.compile_to_file(str(compiled_model_path))
         print("Model compiled successfully")
     except Exception as e:
         print("Model compilation failed:", e)


### PR DESCRIPTION
Code Errors (2):
- get-started.md: WinForms class inherits Form, not Window
- tutorial.md: Use pathlib.Path for .exists() method

Duplicate Code Blocks (1):
- phi-silica-winui-tutorial.md: Remove duplicate InitializeModelAsync code

Missing Helper Methods (2):
- app-content-search-tutorial.md: Add GetIndexerForApp() helper definition
- text-recognition-tutorial.md: Add reference to LoadImageBufferFromFileAsync