### PR TITLE
C++ namespace dot notation errors

### DIFF
--- a/docs/apis/image-foreground-extractor.md
+++ b/docs/apis/image-foreground-extractor.md
@@ -51,7 +51,7 @@ var foregroundMask = model.GetMaskFromSoftwareBitmap(softwareBitmap);
 #include <winrt/Windows.Graphics.Imaging.h>
 #include <winrt/Windows.Foundation.h>
 using namespace winrt::Microsoft::Graphics::Imaging; 
-using namespace winrt::Microsoft::Windows::AI.Imaging;
+using namespace winrt::Microsoft::Windows::AI::Imaging;
 using namespace winrt::Windows::Graphics::Imaging; 
 using namespace winrt::Windows::Foundation;
 

--- a/docs/apis/image-object-erase.md
+++ b/docs/apis/image-object-erase.md
@@ -50,7 +50,7 @@ SoftwareBitmap finalImage = imageObjectRemover.RemoveFromSoftwareBitmap(imageBit
 #include <winrt/Windows.Graphics.Imaging.h>
 #include <winrt/Windows.Foundation.h>
 using namespace winrt::Microsoft::Graphics::Imaging;
-using namespace winrt::Microsoft::Windows::AI.Imaging;
+using namespace winrt::Microsoft::Windows::AI::Imaging;
 using namespace winrt::Windows::Graphics::Imaging; 
 using namespace winrt::Windows::Foundation;
 if (ImageObjectRemover::GetReadyState() == AIFeatureReadyState::NotReady)

--- a/docs/apis/image-object-extractor.md
+++ b/docs/apis/image-object-extractor.md
@@ -80,7 +80,7 @@ SoftwareBitmap finalImage = imageObjectExtractor.GetSoftwareBitmapObjectMask(hin
 #include <winrt/Windows.Graphics.Imaging.h>
 #include <winrt/Windows.Foundation.h>
 using namespace winrt::Microsoft::Graphics::Imaging; 
-using namespace winrt::Microsoft::Windows::AI.Imaging;
+using namespace winrt::Microsoft::Windows::AI::Imaging;
 using namespace winrt::Windows::Graphics::Imaging; 
 using namespace winrt::Windows::Foundation;
 


### PR DESCRIPTION
Fixes C++ compilation errors in 3 API docs where using namespace declarations used dot notation (AI.Imaging) instead of the required C++ double-colon (AI::Imaging) syntax.