### PR TITLE
C# and C++ using directive errors

### DIFF
--- a/docs/apis/image-description.md
+++ b/docs/apis/image-description.md
@@ -57,7 +57,7 @@ using Microsoft.Graphics.Imaging;
 using Microsoft.Windows.Management.Deployment;  
 using Microsoft.Windows.AI;
 using Microsoft.Windows.AI.ContentModeration;
-using Windows.Storage.StorageFile;  
+using Windows.Storage;  
 using Windows.Storage.Streams;  
 using Windows.Graphics.Imaging;
 
@@ -94,7 +94,7 @@ string response = languageModelResponse.Response;
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Graphics.Imaging.h> 
 #include <winrt/Windows.Storage.Streams.h>
-#include <winrt/Windows.Storage.StorageFile.h>
+#include <winrt/Windows.Storage.h>
 
 using namespace winrt::Microsoft::Graphics::Imaging; 
 using namespace winrt::Microsoft::Windows::AI;
@@ -103,7 +103,7 @@ using namespace winrt::Microsoft::Windows::AI::Imaging;
 using namespace winrt::Windows::Foundation; 
 using namespace winrt::Windows::Graphics::Imaging;
 using namespace winrt::Windows::Storage::Streams;
-using namespace winrt::Windows::Storage::StorageFile;    
+using namespace winrt::Windows::Storage;    
 
 if (ImageDescriptionGenerator::GetReadyState() == AIFeatureReadyState::NotReady)
 {

--- a/docs/apis/phi-silica.md
+++ b/docs/apis/phi-silica.md
@@ -128,7 +128,7 @@ This example demonstrates the text summarizing skill.
 1. Pass some text to the [**SummarizeAsync**](/windows/windows-app-sdk/api/winrt/microsoft.windows.ai.text.textsummarizer.summarizeasync) method and print the result.
 
 ```csharp
-using namespace Microsoft.Windows.AI.Text;
+using Microsoft.Windows.AI.Text;
 
 using LanguageModel languageModel = await LanguageModel.CreateAsync();
 


### PR DESCRIPTION
- phi-silica.md: Fix C# code block using C++ 'using namespace' syntax
- image-description.md: Fix C# using directive referencing class instead of namespace
- image-description.md: Fix C++ using namespace and include for StorageFile (class, not namespace)