### PR TITLE
fix: grammar errors, garbled text, and formatting issues

### DIFF
--- a/docs/cards/microsoft-paint-application-card.md
+++ b/docs/cards/microsoft-paint-application-card.md
@@ -144,7 +144,7 @@ Responsible AI is a shared commitment between Microsoft and its customers. While
 
 ## Learn more about Microsoft Paint
 
-For additional guidance on the responsible use of Microsoft Paint, we recommend reviewing the additional documentation the following.
+For additional guidance on the responsible use of Microsoft Paint, we recommend reviewing the following documentation.
 
 - [Use Copilot+ PC features in Paint](https://support.microsoft.com/windows/use-copilot-pc-features-in-paint-53857513-e36c-472d-8d4a-adbcd14b2e54)
 - [Use Image Creator in Paint to generate AI art](https://support.microsoft.com/windows/use-image-creator-in-paint-to-generate-ai-art-107a2b3a-62ea-41f5-a638-7bc6e6ea718f)

--- a/docs/cards/recall-application-card.md
+++ b/docs/cards/recall-application-card.md
@@ -16,7 +16,7 @@ As part of its commitment to responsible AI, Microsoft adheres to six core princ
 
 ## Overview
 
-Recall (preview) was introduced earlier this year, with the ability to enable you to quickly find and jump back into what you have seen before on your PC. You can use an explorable timeline to find the content you remember seeing before. You can also use semantic powered search and just describe how you remember something and Recall will retrieve the moment you saw it. Any photo, link, or message can be a fresh point to continue from.
+Recall (preview) was introduced in 2024, with the ability to enable you to quickly find and jump back into what you have seen before on your PC. You can use an explorable timeline to find the content you remember seeing before. You can also use semantic powered search and just describe how you remember something and Recall will retrieve the moment you saw it. Any photo, link, or message can be a fresh point to continue from.
 
 To use Recall you need to opt in to saving snapshots, which are screenshots of your activity. Snapshots and the contextual information derived from them are saved and encrypted to your local hard drive. Recall does not share snapshots or associated data with Microsoft or third parties, nor is it shared between different Windows users on the same device. Windows will ask for your permission before saving snapshots. You are always in control of what apps and websites get saved in snapshots, and you can delete snapshots, pause or turn them off at any time. Any future options for the user to share data will require fully informed explicit action by the user.
 

--- a/docs/cards/recall-application-card.md
+++ b/docs/cards/recall-application-card.md
@@ -16,7 +16,7 @@ As part of its commitment to responsible AI, Microsoft adheres to six core princ
 
 ## Overview
 
-Recall (preview) was introduced in 2024, with the ability to enable you to quickly find and jump back into what you have seen before on your PC. You can use an explorable timeline to find the content you remember seeing before. You can also use semantic powered search and just describe how you remember something and Recall will retrieve the moment you saw it. Any photo, link, or message can be a fresh point to continue from.
+Recall (preview) was introduced in 2024, with the ability to enable you to quickly find and jump back into what you have seen before on your PC. You can use an explorable timeline to find the content you remember seeing before. You can also use semantic-powered search and just describe how you remember something and Recall will retrieve the moment you saw it. Any photo, link, or message can be a fresh point to continue from.
 
 To use Recall you need to opt in to saving snapshots, which are screenshots of your activity. Snapshots and the contextual information derived from them are saved and encrypted to your local hard drive. Recall does not share snapshots or associated data with Microsoft or third parties, nor is it shared between different Windows users on the same device. Windows will ask for your permission before saving snapshots. You are always in control of what apps and websites get saved in snapshots, and you can delete snapshots, pause or turn them off at any time. Any future options for the user to share data will require fully informed explicit action by the user.
 

--- a/docs/cloud-ai.md
+++ b/docs/cloud-ai.md
@@ -29,21 +29,21 @@ Choosing between cloud-based and local AI models depends on your specific needs 
 
 - **Data privacy, compliance, and security**
   
-  - - **Local, on-premises:** Since data remains on the device, running a model locally can offer benefits regarding security and privacy, with the responsibility of data security resting on the user. The developer holds responsibility for managing updates, ensuring compatibility, and monitoring security vulnerabilities.
+  - **Local, on-premises:** Since data remains on the device, running a model locally can offer benefits regarding security and privacy, with the responsibility of data security resting on the user. The developer holds responsibility for managing updates, ensuring compatibility, and monitoring security vulnerabilities.
   
-  - - **Cloud:** Cloud providers offer robust security measures, but data needs to be transferred to the cloud, which might raise data privacy concerns for the business or app service maintainer in some cases. Sending data to the cloud also must comply with data protection regulations, such as GDPR or HIPAA, depending on the nature of the data and the region in which the app operates. Cloud providers typically handle security updates and maintenance, but users must ensure that they are using secure APIs and following best practices for data handling.
+  - **Cloud:** Cloud providers offer robust security measures, but data needs to be transferred to the cloud, which might raise data privacy concerns for the business or app service maintainer in some cases. Sending data to the cloud also must comply with data protection regulations, such as GDPR or HIPAA, depending on the nature of the data and the region in which the app operates. Cloud providers typically handle security updates and maintenance, but users must ensure that they are using secure APIs and following best practices for data handling.
 
 - **Resource availability**
 
   - **Local, on-premises:** Running a model depends on the resources available on the device being used, including the CPU, GPU, NPU, memory, and storage capacity. This can be limiting if the device does not have high computational power or sufficient storage. Small Language Models (SLMs), like [Phi](./apis/phi-silica.md), are more suitable for local use on a device. [Copilot+ PCs](https://www.microsoft.com/windows/copilot-plus-pcs) offer built-in models with ready-to-use AI features supported by [Microsoft Foundry on Windows](./apis/index.md).
   
-  - - **Cloud:** Cloud platforms, such as [Azure AI Services](/azure/ai-services/), offer scalable resources. You can use as much computational power or storage as you need and only pay for what you use. Large Language Models (LLMs), like the [OpenAI language models](https://platform.openai.com/docs/models), require more resources, but are also more powerful.
+  - **Cloud:** Cloud platforms, such as [Azure AI Services](/azure/ai-services/), offer scalable resources. You can use as much computational power or storage as you need and only pay for what you use. Large Language Models (LLMs), like the [OpenAI language models](https://platform.openai.com/docs/models), require more resources, but are also more powerful.
 
 - **Accessibility and collaboration**
   
-  - - **Local, on-premises:** The model and data are accessible only on the device unless shared manually. This has the potential to make collaboration on model data more challenging.
+  - **Local, on-premises:** The model and data are accessible only on the device unless shared manually. This has the potential to make collaboration on model data more challenging.
   
-  - - **Cloud:** The model and data can be accessed from anywhere with internet connectivity. This may be better for collaboration scenarios.
+  - **Cloud:** The model and data can be accessed from anywhere with internet connectivity. This may be better for collaboration scenarios.
 
 - **Cost**
 

--- a/docs/new-windows-ml/models.md
+++ b/docs/new-windows-ml/models.md
@@ -13,7 +13,7 @@ To learn more about Windows ML, see [What is Windows ML](./overview.md).
 
 | Options | Details |
 |-------|---------|
-| **[1. Use models from Foundry Toolkit](#option-1-use-models-from-foundry-toolkit)** | Choose from [over 20+ OSS models](https://github.com/microsoft/olive-recipes/blob/main/.aitk/docs/guide/ModelList.md) (including LLMs and other types of models) that are ready-to-optimize for use with Windows ML using [Foundry Toolkit's Conversion tool](https://code.visualstudio.com/docs/intelligentapps/modelconversion) |
+| **[1. Use models from Foundry Toolkit](#option-1-use-models-from-foundry-toolkit)** | Choose from [20+ OSS models](https://github.com/microsoft/olive-recipes/blob/main/.aitk/docs/guide/ModelList.md) (including LLMs and other types of models) that are ready-to-optimize for use with Windows ML using [Foundry Toolkit's Conversion tool](https://code.visualstudio.com/docs/intelligentapps/modelconversion) |
 | **[2. Use other existing ONNX models](#option-2-use-other-existing-onnx-models)** | Browse over 30,000+ [pre-trained ONNX models from Hugging Face](https://huggingface.co/models?library=onnx) or other sources |
 | **[3. Convert existing models to ONNX format](#option-3-convert-existing-models-to-onnx-format)** | Browse over 2,400,000+ [pre-trained PyTorch / TensorFlow / etc models from Hugging Face](https://huggingface.co/models) or other sources and convert them to ONNX |
 | **[4. Fine-tune existing models](#option-4-fine-tune-existing-models)** | Fine-tune over 2,400,000+ [pre-trained PyTorch / TensorFlow / etc models from Hugging Face](https://huggingface.co/models) or other sources to work better for your scenario (and convert them to ONNX format)

--- a/docs/new-windows-ml/versioning.md
+++ b/docs/new-windows-ml/versioning.md
@@ -7,7 +7,7 @@ ms.topic: how-to
 
 # Check execution provider versions in Windows ML
 
-Most execution providers in Windows ML are dynamically acquired via Windows Update at runtime as seen in [Install Windows ML EPs](./initialize-execution-providers.md), and updated versions are automatically updated (with compatible updates) as described in [Update Windows ML EPs](./update-execution-providers.md), meaning the version of the EP might vary over time.
+Most execution providers in Windows ML are dynamically acquired via Windows Update at runtime as seen in [Install Windows ML EPs](./initialize-execution-providers.md), and are automatically updated (with compatible updates) as described in [Update Windows ML EPs](./update-execution-providers.md), meaning the version of the EP might vary over time.
 
 See the [supported execution providers docs](./supported-execution-providers.md) to see what execution providers are available and their release history.
 

--- a/docs/npu-devices/index.md
+++ b/docs/npu-devices/index.md
@@ -166,6 +166,7 @@ Additional performance measurement tools to consider using with the Microsoft Wi
 
 - [Microsoft Foundry on Windows overview](../overview.md)
 - [Windows app performance and fundamentals overview](/windows/apps/performance/)
-- [Windows on Arm overview](/windows/arm/overview)- [Empowering the future: The expanding Arm app ecosystem for Copilot+ PCs](https://blogs.windows.com/windowsdeveloper/2025/09/18/empowering-the-future-the-expanding-arm-app-ecosystem-for-copilot-pcs/)
+- [Windows on Arm overview](/windows/arm/overview)
+- [Empowering the future: The expanding Arm app ecosystem for Copilot+ PCs](https://blogs.windows.com/windowsdeveloper/2025/09/18/empowering-the-future-the-expanding-arm-app-ecosystem-for-copilot-pcs/)
 - [What is Windows ML](../new-windows-ml/overview.md)
 - [All about neural processing units (NPUs)](https://support.microsoft.com/windows/all-about-neural-processing-units-npus-e77a5637-7705-4915-96c8-0c6a975f9db4)

--- a/docs/rai.md
+++ b/docs/rai.md
@@ -107,7 +107,7 @@ Recommended practices include:
 
   - Limit length of input and output where appropriate
 
-  - Provide structure out input or output – prompts must follow a standard format
+  - Provide structured input or output – prompts must follow a standard format
 
   - Prepare pre-determined responses for controversial prompts.
 


### PR DESCRIPTION
## Summary

Fixes grammar errors, garbled text, redundant phrasing, and formatting issues across 7 files in the windows-ai docset.

## Changes

| # | File | Fix |
|---|------|-----|
| 1 | docs/cards/microsoft-paint-application-card.md | Fixed garbled sentence: 'reviewing the additional documentation the following' to 'reviewing the following documentation' |
| 2 | docs/rai.md | Fixed grammar: 'Provide structure out input or output' to 'Provide structured input or output' |
| 3 | docs/cards/recall-application-card.md | Replaced time-relative 'earlier this year' with specific 'in 2024' |
| 4 | docs/new-windows-ml/versioning.md | Fixed redundancy: 'updated versions are automatically updated' to 'are automatically updated' |
| 5 | docs/new-windows-ml/models.md | Fixed redundancy: 'over 20+ OSS models' to '20+ OSS models' |
| 6 | docs/npu-devices/index.md | Added missing line break between two concatenated list items in Additional Resources |
| 7 | docs/cloud-ai.md | Fixed inconsistent list formatting: removed double dashes for sub-items, using consistent single-dash indentation |

## Skipped Findings

None - all 7 findings addressed.