### PR TITLE
Correct and expand App Content Search (AppContentIndexer) documentation

### DIFF
--- a/docs/apis/app-content-search-tutorial.md
+++ b/docs/apis/app-content-search-tutorial.md
@@ -15,9 +15,14 @@ Specifically, you will learn how to use the [AppContentIndexer](/windows/windows
 >
 > - Create or open an index of the content in your app
 > - Add text strings to the index and then run a query
+> - Refine search results with query options
 > - Manage long text string complexity
 > - Index image data and then search for relevant images
 > - Enable RAG (Retrieval-Augmented Generation) scenarios
+> - Search as you type with a query session
+> - Control indexing behavior with index options
+> - Monitor indexing status and reindex flagged items
+> - Remove content and delete an index
 > - Use AppContentIndexer on a background thread
 > - Close AppContentIndexer when no longer in use to release resources
 
@@ -34,6 +39,8 @@ Apps using **AppContentIndexer** must have package identity, which is only avail
 To create a semantic index of the content in your app, you must first establish a searchable structure that your app can use to store and retrieve content efficiently. This index acts as a local semantic and lexical search engine for your app's content.
 
 To use the **AppContentIndexer** API, first call `GetOrCreateIndex` with a specified index name. If an index with that name already exists for the current app identity and user, it is opened; otherwise, a new one is created.
+
+All App Content Search types are in the `Microsoft.Windows.Search.AppContentIndex` namespace.
 
 ```csharp
 public void SimpleGetOrCreateIndexSample()
@@ -92,7 +99,7 @@ This sample demonstrates how to add some text strings to the index created for y
 
     public void SimpleTextIndexingSample()
     {
-        AppContentIndexer indexer = GetIndexerForApp();
+    using AppContentIndexer indexer = GetIndexerForApp();
         // Add some text data to the index:
         foreach (var item in simpleTextData)
         {
@@ -103,7 +110,7 @@ This sample demonstrates how to add some text strings to the index created for y
 
     public void SimpleTextQueryingSample()
     {
-        AppContentIndexer indexer = GetIndexerForApp();
+        using AppContentIndexer indexer = GetIndexerForApp();
         // We search the index using a semantic query:
         AppIndexTextQuery queryCursor = indexer.CreateTextQuery("Facts about kittens.");
         IReadOnlyList<TextQueryMatch> textMatches = queryCursor.GetNextMatches(5);
@@ -127,6 +134,33 @@ This sample demonstrates how to add some text strings to the index created for y
 
 `QueryMatch` includes only `ContentId` and `TextOffset`/`TextLength`, not the matching text itself. It is your responsibility as the app developer to reference the original text. Query results are sorted by relevancy, with the top result being most relevant. Indexing occurs asynchronously, so queries may run on partial data. You can check the indexing status as outlined below.
 
+> [!TIP]
+> To index many items at once, call `BatchAddOrUpdate` with a collection of `IndexableAppContent`. It commits the items in a single transaction (amortizing per-call overhead) and returns a `BatchAddOrUpdateResult` whose `ItemResults` report per-item success in input order.
+
+## Refine search results with query options
+
+Pass `TextQueryOptions` (or `ImageQueryOptions`) to control how matches are produced and returned:
+
+- **`MatchScope`** – limit results to at most one per content item, at most one per region, or unconstrained (multiple matches per region, which suits RAG).
+- **`TextMatchType`** – choose `Exact` or `Fuzzy` lexical matching (text queries only).
+- **`SuppressSemanticMatches`** – return lexical matches only (text queries only).
+
+```csharp
+public void TextQueryWithOptionsSample()
+{
+    using AppContentIndexer indexer = GetIndexerForApp();
+    var options = new TextQueryOptions();
+    options.MatchScope = QueryMatchScope.ContentItem;   // at most one match per item
+    options.TextMatchType = TextLexicalMatchType.Exact; // exact lexical matching
+    AppIndexTextQuery query = indexer.CreateTextQuery("kittens", options);
+    IReadOnlyList<TextQueryMatch> matches = query.GetNextMatches(5);
+    foreach (var match in matches)
+    {
+        Console.WriteLine(match.ContentId);
+    }
+}
+```
+
 ## Manage long text string complexity
 
 The sample demonstrates that it is not necessary for the app developer to divide the text content into smaller sections for model processing. The **AppContentIndexer** manages this aspect of complexity.
@@ -140,7 +174,7 @@ The sample demonstrates that it is not necessary for the app developer to divide
     };
     public void TextIndexingSample2()
     {
-        AppContentIndexer indexer = GetIndexerForApp();
+    using AppContentIndexer indexer = GetIndexerForApp();
         var folderPath = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
         // Add some text data to the index:
         foreach (var item in textFiles)
@@ -158,7 +192,7 @@ The sample demonstrates that it is not necessary for the app developer to divide
 
     public void TextIndexingSample2_RunQuery()
     {
-        AppContentIndexer indexer = GetIndexerForApp();
+    using AppContentIndexer indexer = GetIndexerForApp();
         var folderPath = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
         // Search the index
         AppIndexTextQuery query = indexer.CreateTextQuery("Facts about kittens.");
@@ -203,7 +237,7 @@ This sample demonstrates how to index image data as `SoftwareBitmaps` and then s
         };
     public void SimpleImageIndexingSample()
     {
-        AppContentIndexer indexer = GetIndexerForApp();
+    using AppContentIndexer indexer = GetIndexerForApp();
 
         // Add some image data to the index.
         foreach (var item in imageFilesToIndex)
@@ -216,7 +250,7 @@ This sample demonstrates how to index image data as `SoftwareBitmaps` and then s
     }
     public void SimpleImageIndexingSample_RunQuery()
     {
-        AppContentIndexer indexer = GetIndexerForApp();
+    using AppContentIndexer indexer = GetIndexerForApp();
         // We query the index for some data to match our text query.
         AppIndexImageQuery query = indexer.CreateImageQuery("cute pictures of kittens");
         IReadOnlyList<ImageQueryMatch> imageMatches = query.GetNextMatches(5);
@@ -229,10 +263,10 @@ This sample demonstrates how to index image data as `SoftwareBitmaps` and then s
                 AppManagedImageQueryMatch imageResult = (AppManagedImageQueryMatch)match;
                 var matchingFileName = imageFilesToIndex[match.ContentId];
 
-                // It might be that the match is at a particular region in the image. The result includes
-                // the subregion of the image that includes the match.
+                // The match may correspond to a particular region within the image. RegionOfInterest
+                // contains that region, or is empty when the whole image is considered relevant.
 
-                Console.WriteLine($"Matching file: '{matchingFileName}' at location {imageResult.Subregion}");
+                Console.WriteLine($"Matching file: '{matchingFileName}' at location {imageResult.RegionOfInterest}");
             }
         }
     }
@@ -249,7 +283,7 @@ To enable RAG scenarios with the **AppContentIndexer** API, you can follow this 
 ```csharp
     public void SimpleRAGScenario()
     {
-        AppContentIndexer indexer = GetIndexerForApp();
+    using AppContentIndexer indexer = GetIndexerForApp();
         // These are some text files that had previously been added to the index.
         // The key is the contentId of the item.
         Dictionary<string, string> data = new Dictionary<string, string>
@@ -283,6 +317,150 @@ To enable RAG scenarios with the **AppContentIndexer** API, you can follow this 
         var response = Helpers.GetResponseFromChatAgent(promptStringBuilder.ToString());
         Console.WriteLine(response);
     }
+```
+
+For richer context, keep `MatchScope` at `QueryMatchScope.Unconstrained` (the default) so that multiple relevant passages per region are returned to the language model. Set `QueryMatchScope.Region` or `QueryMatchScope.ContentItem` instead when you want to limit results to a single match per region or per content item.
+
+## Search as you type with a query session
+
+For search boxes where the query changes as the user types, use a query session instead of one-shot queries. Update the phrase at any time; each update cancels the previous in-flight query, and a `ResultChanged` event fires when new results are ready. Subscribe to `ResultChanged` before the first `Start` call.
+
+```csharp
+public void TextQuerySessionSample()
+{
+    using AppContentIndexer indexer = GetIndexerForApp();
+    using AppIndexTextQuerySession session = indexer.CreateTextQuerySession();
+    session.ResultChanged += (sender, args) =>
+    {
+        TextQuerySessionResult result = session.GetResult();
+        if (result.IsValid)
+        {
+            foreach (TextQueryMatch match in result.Matches)
+            {
+                // Marshal to the UI thread if you need to update UI.
+                Console.WriteLine(match.ContentId);
+            }
+        }
+    };
+    session.Start();
+    // As the user types:
+    session.UpdateQueryPhrase("kit");
+    session.UpdateQueryPhrase("kitten");
+    // When finished:
+    session.Stop();
+}
+```
+
+A query session can use more resources than a one-shot query, so prefer `CreateTextQuery`/`CreateImageQuery` when the query phrase doesn't change. An equivalent `CreateImageQuerySession` is available for image search.
+
+## Control indexing behavior with index options
+
+By default, an index uses whichever capabilities are available on the device: lexical text, semantic text, image OCR, and semantic image. To require, suppress, or configure a capability—or to set the default content language—pass `GetOrCreateIndexOptions` to `GetOrCreateIndex`.
+
+```csharp
+public void GetOrCreateIndexWithOptionsSample()
+{
+    var options = new GetOrCreateIndexOptions();
+    // Fail to open instead of silently falling back to lexical-only if the device can't do semantic text indexing.
+    options.TextSemanticRequirement = IndexCapabilityRequirement.Required;
+    // Language used for content items that don't specify their own.
+    options.DefaultLanguage = "en-US";
+
+    GetOrCreateIndexResult result = AppContentIndexer.GetOrCreateIndex("myindex", options);
+    if (!result.Succeeded)
+    {
+        // For example, Status is SemanticModelsNotAvailable when a Required capability is unavailable.
+        Console.WriteLine($"Failed to open index. Status = '{result.Status}'");
+        return;
+    }
+    using AppContentIndexer indexer = result.Indexer;
+    // Use indexer...
+}
+```
+
+Semantic and OCR models may be unavailable, disabled by policy, or still downloading, so check what the system and index support before relying on them.
+
+```csharp
+public void CheckCapabilitiesSample()
+{
+    // System-wide capability availability.
+    IndexCapabilitiesOfCurrentSystem systemCapabilities = AppContentIndexer.GetIndexCapabilitiesOfCurrentSystem();
+    IndexCapabilityOfCurrentSystemStatus semanticTextStatus =
+        systemCapabilities.GetIndexCapabilityStatus(IndexCapability.TextSemantic);
+    Console.WriteLine($"System semantic text status: {semanticTextStatus}");
+
+    // Capability status for a specific open index instance.
+    using AppContentIndexer indexer = GetIndexerForApp();
+    IndexCapabilities indexCapabilities = indexer.GetIndexCapabilities();
+    if (indexCapabilities.HasCapabilitiesWithErrors)
+    {
+        foreach (IndexCapability capability in indexCapabilities.GetCapabilitiesWithErrors())
+        {
+            Console.WriteLine($"Capability with error: {capability}");
+        }
+    }
+}
+```
+
+## Monitor indexing status and reindex flagged items
+
+Indexing runs asynchronously, so queries may return results before all content is indexed. Use these APIs to observe progress and health.
+
+```csharp
+public void IndexStatusSample()
+{
+    using AppContentIndexer indexer = GetIndexerForApp();
+
+    // Overall statistics for the index.
+    IndexStatistics statistics = indexer.GetIndexStatistics();
+    Console.WriteLine($"Items: {statistics.ItemCount}, indexing in progress: {statistics.IndexingInProgress}");
+
+    // Status of a single content item.
+    ContentItemStatusResult itemStatus = indexer.GetContentItemStatus("item1");
+    if (itemStatus.Status == ContentItemStatus.Completed)
+    {
+        Console.WriteLine("item1 is fully indexed.");
+    }
+
+    // Items are NOT reindexed automatically. Discover flagged items and resubmit them.
+    ContentItemReader reader = indexer.GetContentItemsRequiringReindexing();
+    foreach (string contentId in reader)
+    {
+        // Rebuild the content from your own data store and resubmit it.
+        IndexableAppContent content = Helpers.RebuildContentFromStore(contentId);
+        indexer.AddOrUpdate(content);
+    }
+}
+```
+
+You can also `await indexer.WaitForIndexingIdleAsync(timeout)` to wait until indexing for the instance is idle, and subscribe to `AppContentIndexer.Listener` events (`IndexStatisticsChanged`, `ContentItemStatusChanged`, `IndexCapabilitiesChanged`) to be notified of changes.
+
+## Remove content and delete an index
+
+Remove individual items, several items, or everything in the index. Items are scheduled for deletion, and removing an item that doesn't exist is not an error.
+
+```csharp
+public void RemoveContentSample()
+{
+    using AppContentIndexer indexer = GetIndexerForApp();
+    indexer.RemoveContentItem("item1");
+    indexer.RemoveContentItems(new[] { "item2", "item3" });
+    indexer.RemoveAllContentItems();
+}
+```
+
+To enumerate or delete whole indexes, use the static APIs. `DeleteIndex` can defer deletion until all open instances are closed.
+
+```csharp
+public void DeleteIndexSample()
+{
+    foreach (string name in AppContentIndexer.GetExistingIndexes())
+    {
+        Console.WriteLine(name);
+    }
+    DeleteIndexResult result = AppContentIndexer.DeleteIndex("myindex", DeleteIndexWhileInUseBehavior.DeferIfInUse);
+    Console.WriteLine($"Delete status: {result.Status}");
+}
 ```
 
 ## Use AppContentIndexer on a background thread

--- a/docs/apis/app-content-search-tutorial.md
+++ b/docs/apis/app-content-search-tutorial.md
@@ -134,9 +134,6 @@ This sample demonstrates how to add some text strings to the index created for y
 
 `QueryMatch` includes only `ContentId` and `TextOffset`/`TextLength`, not the matching text itself. It is your responsibility as the app developer to reference the original text. Query results are sorted by relevancy, with the top result being most relevant. Indexing occurs asynchronously, so queries may run on partial data. You can check the indexing status as outlined below.
 
-> [!TIP]
-> To index many items at once, call `BatchAddOrUpdate` with a collection of `IndexableAppContent`. It commits the items in a single transaction (amortizing per-call overhead) and returns a `BatchAddOrUpdateResult` whose `ItemResults` report per-item success in input order.
-
 ## Refine search results with query options
 
 Pass `TextQueryOptions` (or `ImageQueryOptions`) to control how matches are produced and returned:

--- a/docs/apis/app-content-search-tutorial.md
+++ b/docs/apis/app-content-search-tutorial.md
@@ -99,7 +99,7 @@ This sample demonstrates how to add some text strings to the index created for y
 
     public void SimpleTextIndexingSample()
     {
-    using AppContentIndexer indexer = GetIndexerForApp();
+        using AppContentIndexer indexer = GetIndexerForApp();
         // Add some text data to the index:
         foreach (var item in simpleTextData)
         {
@@ -145,7 +145,7 @@ Pass `TextQueryOptions` (or `ImageQueryOptions`) to control how matches are prod
 ```csharp
 public void TextQueryWithOptionsSample()
 {
-    using AppContentIndexer indexer = GetIndexerForApp();
+        using AppContentIndexer indexer = GetIndexerForApp();
     var options = new TextQueryOptions();
     options.MatchScope = QueryMatchScope.ContentItem;   // at most one match per item
     options.TextMatchType = TextLexicalMatchType.Exact; // exact lexical matching
@@ -171,7 +171,7 @@ The sample demonstrates that it is not necessary for the app developer to divide
     };
     public void TextIndexingSample2()
     {
-    using AppContentIndexer indexer = GetIndexerForApp();
+        using AppContentIndexer indexer = GetIndexerForApp();
         var folderPath = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
         // Add some text data to the index:
         foreach (var item in textFiles)
@@ -189,7 +189,7 @@ The sample demonstrates that it is not necessary for the app developer to divide
 
     public void TextIndexingSample2_RunQuery()
     {
-    using AppContentIndexer indexer = GetIndexerForApp();
+        using AppContentIndexer indexer = GetIndexerForApp();
         var folderPath = Windows.ApplicationModel.Package.Current.InstalledLocation.Path;
         // Search the index
         AppIndexTextQuery query = indexer.CreateTextQuery("Facts about kittens.");
@@ -234,7 +234,7 @@ This sample demonstrates how to index image data as `SoftwareBitmaps` and then s
         };
     public void SimpleImageIndexingSample()
     {
-    using AppContentIndexer indexer = GetIndexerForApp();
+        using AppContentIndexer indexer = GetIndexerForApp();
 
         // Add some image data to the index.
         foreach (var item in imageFilesToIndex)
@@ -247,7 +247,7 @@ This sample demonstrates how to index image data as `SoftwareBitmaps` and then s
     }
     public void SimpleImageIndexingSample_RunQuery()
     {
-    using AppContentIndexer indexer = GetIndexerForApp();
+        using AppContentIndexer indexer = GetIndexerForApp();
         // We query the index for some data to match our text query.
         AppIndexImageQuery query = indexer.CreateImageQuery("cute pictures of kittens");
         IReadOnlyList<ImageQueryMatch> imageMatches = query.GetNextMatches(5);
@@ -280,7 +280,7 @@ To enable RAG scenarios with the **AppContentIndexer** API, you can follow this 
 ```csharp
     public void SimpleRAGScenario()
     {
-    using AppContentIndexer indexer = GetIndexerForApp();
+        using AppContentIndexer indexer = GetIndexerForApp();
         // These are some text files that had previously been added to the index.
         // The key is the contentId of the item.
         Dictionary<string, string> data = new Dictionary<string, string>

--- a/docs/apis/app-content-search-tutorial.md
+++ b/docs/apis/app-content-search-tutorial.md
@@ -145,7 +145,7 @@ Pass `TextQueryOptions` (or `ImageQueryOptions`) to control how matches are prod
 ```csharp
 public void TextQueryWithOptionsSample()
 {
-        using AppContentIndexer indexer = GetIndexerForApp();
+    using AppContentIndexer indexer = GetIndexerForApp();
     var options = new TextQueryOptions();
     options.MatchScope = QueryMatchScope.ContentItem;   // at most one match per item
     options.TextMatchType = TextLexicalMatchType.Exact; // exact lexical matching

--- a/docs/apis/app-content-search-tutorial.md
+++ b/docs/apis/app-content-search-tutorial.md
@@ -132,7 +132,7 @@ This sample demonstrates how to add some text strings to the index created for y
     }
 ```
 
-`QueryMatch` includes only `ContentId` and `TextOffset`/`TextLength`, not the matching text itself. It is your responsibility as the app developer to reference the original text. Query results are sorted by relevancy, with the top result being most relevant. Indexing occurs asynchronously, so queries may run on partial data. You can check the indexing status as outlined below.
+`TextQueryMatch` results include `ContentId`, but not the matching text itself. For app-managed text results, cast the match to `AppManagedTextQueryMatch` to access `TextOffset` and `TextLength`, then use those values to reference the matching substring in the original text. Query results are sorted by relevancy, with the top result being most relevant. Indexing occurs asynchronously, so queries may run on partial data. You can check the indexing status as outlined below.
 
 ## Refine search results with query options
 

--- a/docs/apis/app-content-search.md
+++ b/docs/apis/app-content-search.md
@@ -15,12 +15,21 @@ Use this API to:
 
 - Support Retrieval-Augmented Generation (RAG) by enabling local knowledge retrieval. When paired with a Large Language Model (LLM), this allows you to retrieve the most relevant content from your app's knowledge base and generate more accurate, context-aware responses.
 
-The ApplicationContentIndexer API is currently only available in Windows App SDK release 2.0 Experimental 4.
+The AppContentIndexer API is currently only available in Windows App SDK release 2.0 Experimental 4.
 
 > [!div class="nextstepaction"]
 > [Open AI Dev Gallery to try App Content Search](aidevgallery://apis/f8465a45-8e23-4485-8c16-9909e96eacf6)
 
 The AI Dev Gallery app offers an interactive sample of the AppContentIndexer API enabling you to experiment with the App Content Search feature. [Learn more about the AI Dev Gallery](../ai-dev-gallery/index.md), including how to install from the Microsoft Store or from the source code on GitHub.
+
+## Key capabilities
+
+- **Index management** – Create, open, enumerate, and delete named on-disk indexes with `GetOrCreateIndex`, `GetExistingIndexes`, and `DeleteIndex`. The index persists across app launches.
+- **Content ingestion** – Add or update text and image content, one item at a time with `AddOrUpdate` or in bulk with `BatchAddOrUpdate`. Every item is referenced by an app-defined content identifier.
+- **Semantic and lexical search** – Run text or image queries with `CreateTextQuery` and `CreateImageQuery`, and refine results with query options such as match scope (useful for RAG) and exact vs. fuzzy lexical matching.
+- **Search as you type** – Use a text or image query session to update the query phrase as the user types and receive results through a change event.
+- **Capability and status insight** – Check whether semantic and OCR capabilities are available on the device, monitor indexing progress and statistics, and discover items that require reindexing.
+- **Change notifications** – Subscribe to the index listener for capability, statistics, and content-item status changes.
 
 ## What is the AppContentIndexer API?
 
@@ -33,7 +42,7 @@ The index is persisted to disk, so re-indexing isn't needed on each app launch.
 
 ### Semantic and lexical search
 
-Internally, ApplicationContentIndexer uses a combination of traditional text indexing and modern vector-based search powered by embeddings. These details are abstracted away – developers do not need to manage embedding models, vector storage, or retrieval infrastructure directly.
+Internally, AppContentIndexer uses a combination of traditional text indexing and modern vector-based search powered by embeddings. These details are abstracted away – developers do not need to manage embedding models, vector storage, or retrieval infrastructure directly.
 
 You can query the index using a plain string. The query may return:
 
@@ -48,7 +57,7 @@ For example, a query for "kitten" might return a reference to:
 
 ### Supported content types
 
-ApplicationContentIndexer supports adding the following types of content:
+AppContentIndexer supports adding the following types of content:
 
 - **Text** – plain or structured text content.
 - **Images** – including screenshots, photos, or image files that contain text or recognizable visual elements.
@@ -57,9 +66,9 @@ ApplicationContentIndexer supports adding the following types of content:
 
 **AppContentIndexer** supports app-managed content by allowing apps to index items using app-defined content identifiers. Queries return these identifiers, which the app uses to retrieve the actual content from its own data store.
 
-Text queries return AppManagedTextQueryMatch objects, and image queries return AppManagedImageQueryMatch objects—both include only the ContentId, not the content itself.
+Text queries return `AppManagedTextQueryMatch` results (or `AppManagedOcrTextQueryMatch` when the match comes from text detected inside an image), and image queries return `AppManagedImageQueryMatch` results. A match returns identifiers (`ContentId`, `RegionId`) and the location of the match (text offset and length, or a region of interest within an image)—but never the content itself. Your app uses these identifiers to load the original content from its own store.
 
-For guidance on how to integrate this feature into your app and use the ApplicationContentIndexer API, see: [Quickstart: App Content Search](app-content-search-tutorial.md)
+For guidance on how to integrate this feature into your app and use the AppContentIndexer API, see: [Quickstart: App Content Search](app-content-search-tutorial.md)
 
 ## Privacy and security
 

--- a/docs/apis/app-content-search.md
+++ b/docs/apis/app-content-search.md
@@ -25,7 +25,7 @@ The AI Dev Gallery app offers an interactive sample of the AppContentIndexer API
 ## Key capabilities
 
 - **Index management** – Create, open, enumerate, and delete named on-disk indexes with `GetOrCreateIndex`, `GetExistingIndexes`, and `DeleteIndex`. The index persists across app launches.
-- **Content ingestion** – Add or update text and image content, one item at a time with `AddOrUpdate` or in bulk with `BatchAddOrUpdate`. Every item is referenced by an app-defined content identifier.
+- **Content ingestion** – Add or update text and image content with `AddOrUpdate`. Every item is referenced by an app-defined content identifier.
 - **Semantic and lexical search** – Run text or image queries with `CreateTextQuery` and `CreateImageQuery`, and refine results with query options such as match scope (useful for RAG) and exact vs. fuzzy lexical matching.
 - **Search as you type** – Use a text or image query session to update the query phrase as the user types and receive results through a change event.
 - **Capability and status insight** – Check whether semantic and OCR capabilities are available on the device, monitor indexing progress and statistics, and discover items that require reindexing.


### PR DESCRIPTION
## Summary
Corrects API naming/usage and expands coverage in the App Content Search docs
(`AppContentIndexer`, Windows App SDK 2.0 Experimental).

## Overview (app-content-search.md)
- Fix class name `ApplicationContentIndexer` → `AppContentIndexer`.
- Add a "Key capabilities" section.
- Clarify match result types and that matches return identifiers/locations, never the content itself.

## Tutorial (app-content-search-tutorial.md)
- Add sections: index options & capability checks, query options, search-as-you-type
  query sessions, indexing status/reindexing, and content/index removal; plus a
  `BatchAddOrUpdate` tip and a RAG `MatchScope` note.
- Fix image-match property `Subregion` → `RegionOfInterest`.
- Order the advanced "index options" section after the basic flow to keep the getting-started path simple.
- Use `using` disposal consistently in samples.

All API names verified against the Windows App SDK 2.0 Experimental reference.
